### PR TITLE
Added itest for chef_client:parse_binary_json.

### DIFF
--- a/src/chef_client.erl
+++ b/src/chef_client.erl
@@ -85,7 +85,7 @@ set_name_values(Client, ReqName) ->
     % TODO: Can this be simplified?  Several of these cases are duplicates; doesn't
     % seem to be a case where reordering really solves the issue
     case {Name, ClientName, ReqName} of
-        {undefined, undefined, undefined} ->
+        {undefined, undefined, _} ->
             throw({both_missing, <<"name">>, <<"clientname">>});
         {Name, Name, undefined} ->
             {Name, Client};

--- a/test/chef_client_tests.erl
+++ b/test/chef_client_tests.erl
@@ -1,0 +1,51 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92-*-
+%% ex: ts=4 sw=4 et
+%% @author James Casey <james@opscode.com>
+%% @copyright 2012 Opscode, Inc.
+
+-module(chef_client_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+parse_binary_json_test_() ->
+    [{"Error thrown on mismatched names",
+      fun() ->
+          Body = <<"{\"name\":\"name\",\"clientname\":\"notname\"}">>,
+          ?assertThrow({client_name_mismatch}, chef_client:parse_binary_json(Body, <<"name">>))
+      end
+     },
+     {"Can create with only name",
+      fun() ->
+          Body = <<"{\"name\":\"name\"}">>,
+          {ok, Client} = chef_client:parse_binary_json(Body, <<"name">>),
+          Name = ej:get({<<"name">>}, Client),
+          ClientName = ej:get({<<"clientname">>}, Client),
+          ?assertEqual(Name, ClientName)
+      end
+     },
+     {"Can create with only clientname",
+      fun() ->
+          Body = <<"{\"clientname\":\"name\"}">>,
+          {ok, Client} = chef_client:parse_binary_json(Body, <<"name">>),
+          Name = ej:get({<<"name">>}, Client),
+          ClientName = ej:get({<<"clientname">>}, Client),
+          ?assertEqual(Name, ClientName)
+      end
+     },
+     {"Error thrown with no name or clientname",
+      fun() ->
+          Body = <<"{\"validator\":false}">>,
+          ?assertThrow({both_missing, <<"name">>, <<"clientname">>},
+                       chef_client:parse_binary_json(Body, <<"foo">>))
+      end
+     },
+     {"Error thrown with bad name",
+      fun() ->
+          Body = <<"{\"name\":\"bad~name\"}">>,
+          ?assertThrow({bad_client_name, <<"bad~name">>,
+                        <<"Malformed client name.  Must be A-Z, a-z, 0-9, _, -, or .">>},
+                       chef_client:parse_binary_json(Body, <<"bad~name">>))
+      end
+     }
+    ].
+


### PR DESCRIPTION
fix bug where both_missing was not being thrown due to an overmatch
