### PR TITLE
Stub authz IDs in new_record

### DIFF
--- a/src/chef_object.erl
+++ b/src/chef_object.erl
@@ -381,7 +381,7 @@ name(#chef_data_bag_item{data_bag_name = BagName, item_name = ItemName}) ->
 name(#chef_cookbook_version{name = Name}) ->
     Name.
 
--spec type_name(chef_object()) -> chef_type().
+-spec type_name(chef_object()) -> chef_type() | cookbook_version.
 %% @doc Return the common type name of a `chef_object()' record. For example, the common
 %% type name of a `chef_node{}' record is `node'.
 type_name(#chef_data_bag{}) ->

--- a/src/chef_object.erl
+++ b/src/chef_object.erl
@@ -42,7 +42,7 @@
 
 -spec new_record(RecType :: chef_object_name() | chef_cookbook_version,
                  OrgId :: object_id(),
-                 AuthzId :: object_id(),
+                 AuthzId :: object_id() | unset,
                  ObjectEjson :: ejson_term() |
                                 binary() |
                                 {binary(), ejson_term()},
@@ -52,7 +52,7 @@ new_record(chef_environment, OrgId, AuthzId, EnvData, DbType) ->
     Id = make_org_prefix_id(OrgId, Name),
     Data = chef_db_compression:compress(DbType, chef_environment, ejson:encode(EnvData)),
     #chef_environment{id = Id,
-                      authz_id = AuthzId,
+                      authz_id = maybe_stub_authz_id(AuthzId, Id),
                       org_id = OrgId,
                       name = Name,
                       serialized_object = Data};
@@ -63,7 +63,7 @@ new_record(chef_client, OrgId, AuthzId, ClientData, _DbType) ->
     PublicKey =  ej:get({<<"public_key">>}, ClientData),
     PubkeyVersion = ej:get({<<"pubkey_version">>}, ClientData),
     #chef_client{id = Id,
-                 authz_id = AuthzId,
+                 authz_id = maybe_stub_authz_id(AuthzId, Id),
                  org_id = OrgId,
                  name = Name,
                  validator = Validator,
@@ -72,7 +72,7 @@ new_record(chef_client, OrgId, AuthzId, ClientData, _DbType) ->
 new_record(chef_data_bag, OrgId, AuthzId, Name, _DbType) ->
     Id = make_org_prefix_id(OrgId, Name),
     #chef_data_bag{id = Id,
-                   authz_id = AuthzId,
+                   authz_id = maybe_stub_authz_id(AuthzId, Id),
                    org_id = OrgId,
                    name = Name};
 new_record(chef_data_bag_item, OrgId, _AuthzId, {BagName, ItemData}, DbType) ->
@@ -91,7 +91,7 @@ new_record(chef_node, OrgId, AuthzId, NodeData, DbType) ->
     Id = make_org_prefix_id(OrgId, Name),
     Data = chef_db_compression:compress(DbType, chef_node, ejson:encode(NodeData)),
     #chef_node{id = Id,
-               authz_id = AuthzId,
+               authz_id = maybe_stub_authz_id(AuthzId, Id),
                org_id = OrgId,
                name = Name,
                environment = Environment,
@@ -101,7 +101,7 @@ new_record(chef_role, OrgId, AuthzId, RoleData, DbType) ->
     Id = make_org_prefix_id(OrgId, Name),
     Data = chef_db_compression:compress(DbType, chef_role, ejson:encode(RoleData)),
     #chef_role{id = Id,
-               authz_id = AuthzId,
+               authz_id = maybe_stub_authz_id(AuthzId, Id),
                org_id = OrgId,
                name = Name,
                serialized_object = Data};
@@ -134,7 +134,7 @@ new_record(chef_cookbook_version, OrgId, AuthzId, CBVData, DbType) ->
     Data = compress_maybe(ej:delete({<<"metadata">>}, CBVData),
                               chef_cookbook_version, DbType),
     #chef_cookbook_version{id = Id,
-                           authz_id = AuthzId,
+                           authz_id = maybe_stub_authz_id(AuthzId, Id),
                            org_id = OrgId,
                            name = ej:get({<<"cookbook_name">>}, CBVData),
                            major = Major,
@@ -499,3 +499,8 @@ make_org_prefix_id(OrgId, Name) ->
     Bin = iolist_to_binary([OrgId, Name, crypto:rand_bytes(6)]),
     <<ObjectPart:80, _/binary>> = crypto:md5(Bin),
     iolist_to_binary(io_lib:format("~s~20.16.0b", [OrgSuffix, ObjectPart])).
+
+maybe_stub_authz_id(unset, ObjectId) ->
+    ObjectId;
+maybe_stub_authz_id(AuthzId, _ObjectId) ->
+    AuthzId.


### PR DESCRIPTION
I think this is the place where we should stub authz IDs for the various Chef objects. This is somewhat speculative. Until we go through end-to-end with an OSC endpoint, we won't be sure, but as I was cleaning up chef_wm_base and making oc_chef_wm_base work, this started to seem like a logical setup.
