### PR TITLE
Checksum Cleanup

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -14,7 +14,9 @@
         {mini_s3, ".*",
          {git, "git://github.com/opscode/mini_s3.git", {branch, "master"}}},
         {depsolver, ".*",
-         {git, "git://github.com/opscode/depsolver.git", {branch, "master"}}}
+         {git, "git://github.com/opscode/depsolver.git", {branch, "master"}}},
+        {erlware_commons, ".*",
+         {git, "git@github.com:erlware/erlware_commons.git", {branch, "master"}}}
        ]}.
 
 {cover_enabled, true}.

--- a/src/chef_deep_merge.erl
+++ b/src/chef_deep_merge.erl
@@ -19,7 +19,7 @@
 %%
 
 
--module(deep_merge).
+-module(chef_deep_merge).
 
 -export([merge/2]).
 

--- a/src/chef_object.erl
+++ b/src/chef_object.erl
@@ -191,9 +191,9 @@ ejson_for_indexing(#chef_node{name = Name, environment = Environment}, Node) ->
     Override = get_node_part(<<"override">>, Node),
     %% automatic may not always be present
     Automatic = get_node_part(<<"automatic">>, Node),
-    DefaultNormal = deep_merge:merge(Defaults, Normal),
-    DefaultNormalOverride = deep_merge:merge(DefaultNormal, Override),
-    {Merged} = deep_merge:merge(DefaultNormalOverride, Automatic),
+    DefaultNormal = chef_deep_merge:merge(Defaults, Normal),
+    DefaultNormalOverride = chef_deep_merge:merge(DefaultNormal, Override),
+    {Merged} = chef_deep_merge:merge(DefaultNormalOverride, Automatic),
     RunList = value_or_empty_list(<<"run_list">>, Node),
     %% We transform to a dict to ensure we override the top-level keys
     %% with the appropriate values and don't introduce any duplicate

--- a/src/chef_s3.erl
+++ b/src/chef_s3.erl
@@ -2,6 +2,7 @@
 %% ex: ts=4 sw=4 et
 %% @author Mark Anderson <mark@opscode.com>
 %% @author Christopher Maier <cm@opscode.com>
+%% @author Seth Chisamore <schisamo@opscode.com>
 %% @doc chef_s3 - Manage S3 activities for erchef
 %%
 %% Copyright 2012 Opscode, Inc. All Rights Reserved.
@@ -21,13 +22,13 @@
 %% under the License.
 %%
 
-
 -module(chef_s3).
 
 -include("chef_types.hrl").
 
 -export([
          check_checksums/2,
+         delete_checksums/2,
          generate_presigned_url/4,
          generate_presigned_urls/4,
          make_key/2,
@@ -50,6 +51,17 @@
                               {error, non_neg_integer()}}.
 check_checksums(OrgId, Checksums) ->
     s3_ops:fetch_md(OrgId, Checksums).
+
+%% @doc Given a OrgGuid and a list of checksums, delete the checksums, returns a list of
+%% the ones deleted, missing, timeout and errors
+-spec delete_checksums(OrgId :: object_id(),
+                      Checksums :: [binary()]) ->
+                             {{ok, [binary()]},
+                              {missing, [binary()]},
+                              {timeout, non_neg_integer()},
+                              {error, non_neg_integer()}}.
+delete_checksums(OrgId, Checksums) ->
+    s3_ops:delete(OrgId, Checksums).
 
 %% @doc Given an OrgGuid, an expire time, and a list of checksums, returns a list of
 %% {Checksum, Url} tuples

--- a/src/chef_s3.erl
+++ b/src/chef_s3.erl
@@ -50,7 +50,7 @@
                               {missing, [binary()]},
                               {error, non_neg_integer()}}.
 check_checksums(OrgId, Checksums) ->
-    s3_ops:fetch_md(OrgId, Checksums).
+    chef_s3_ops:fetch_md(OrgId, Checksums).
 
 %% @doc Given a OrgGuid and a list of checksums, delete the checksums, returns a list of
 %% the ones deleted, missing, timeout and errors
@@ -61,7 +61,7 @@ check_checksums(OrgId, Checksums) ->
                                {timeout, non_neg_integer()},
                                {error, non_neg_integer()}}.
 delete_checksums(OrgId, Checksums) ->
-    s3_ops:delete(OrgId, Checksums).
+    chef_s3_ops:delete(OrgId, Checksums).
 
 %% @doc Given an OrgGuid, an expire time, and a list of checksums, returns a list of
 %% {Checksum, Url} tuples

--- a/src/chef_s3.erl
+++ b/src/chef_s3.erl
@@ -49,7 +49,7 @@
                               {missing, [binary()]},
                               {error, non_neg_integer()}}.
 check_checksums(OrgId, Checksums) ->
-    s3_metadata:fetch(OrgId, Checksums).
+    s3_ops:fetch_md(OrgId, Checksums).
 
 %% @doc Given an OrgGuid, an expire time, and a list of checksums, returns a list of
 %% {Checksum, Url} tuples

--- a/src/chef_s3.erl
+++ b/src/chef_s3.erl
@@ -55,11 +55,11 @@ check_checksums(OrgId, Checksums) ->
 %% @doc Given a OrgGuid and a list of checksums, delete the checksums, returns a list of
 %% the ones deleted, missing, timeout and errors
 -spec delete_checksums(OrgId :: object_id(),
-                      Checksums :: [binary()]) ->
-                             {{ok, [binary()]},
-                              {missing, [binary()]},
-                              {timeout, non_neg_integer()},
-                              {error, non_neg_integer()}}.
+                       Checksums :: [binary()]) ->
+                              {{ok, [binary()]},
+                               {missing, [binary()]},
+                               {timeout, non_neg_integer()},
+                               {error, non_neg_integer()}}.
 delete_checksums(OrgId, Checksums) ->
     s3_ops:delete(OrgId, Checksums).
 

--- a/src/chef_s3_ops.erl
+++ b/src/chef_s3_ops.erl
@@ -20,7 +20,7 @@
 %% under the License.
 %%
 
--module(s3_ops).
+-module(chef_s3_ops).
 
 -define(MAX, 5).
 -define(TIMEOUT, 5 * 1000).

--- a/src/chef_s3_ops.erl
+++ b/src/chef_s3_ops.erl
@@ -69,10 +69,6 @@ delete(OrgId, Checksums) when is_list(Checksums),
     {Ok, Missing, Timeouts, Errors} =
         lists:foldl(AddResult,
                     {[], [], 0, 0}, lists:flatten(Results)),
-    error_logger:info_msg("Deleted ~p/~p checksums with ~p missing,"
-                          "~p timeouts and ~p errors~n",
-                          [length(Ok), length(Checksums), length(Missing),
-                           Timeouts, Errors]),
     Result = {{ok, lists:sort(Ok)},
               {missing, lists:sort(Missing)},
               {timeout, Timeouts},

--- a/src/s3_ops.erl
+++ b/src/s3_ops.erl
@@ -20,7 +20,7 @@
 %%
 
 
--module(s3_metadata).
+-module(s3_ops).
 
 -define(MAX, 5).
 -define(TIMEOUT, 5 * 1000).
@@ -28,7 +28,7 @@
 -include("chef_types.hrl").
 
 -export([
-         fetch/2
+         fetch_md/2
         ]).
 
 -record(state, {
@@ -45,7 +45,7 @@
          }).
 
 %% @doc Verify that each checksummed file is stored in S3 by checking its metadata
-fetch(OrgId, Checksums) when is_list(Checksums),
+fetch_md(OrgId, Checksums) when is_list(Checksums),
                              is_binary(OrgId) ->
     parallel_fetch(OrgId, Checksums).
 

--- a/src/s3_ops.erl
+++ b/src/s3_ops.erl
@@ -88,17 +88,17 @@ parallel_delete(OrgId, Checksums) ->
     %%  [{value, 1}, {value, 2}, timeout, {badmatch, ...}]
     %%
     ec_plists:ftmap(fun(Checksum) ->
-                    case delete_file(OrgId, Bucket, Checksum) of
-                        {ok, Checksum} -> Checksum;
-                        {Error, Checksum} -> throw({Error, Checksum})
-                    end
-                end,
-                Checksums,
-                ?TIMEOUT).
+                            case delete_file(OrgId, Bucket, Checksum) of
+                                {ok, Checksum} -> Checksum;
+                                {Error, Checksum} -> throw({Error, Checksum})
+                            end
+                    end,
+                    Checksums,
+                    ?TIMEOUT).
 
 %% @doc Verify that each checksummed file is stored in S3 by checking its metadata
 fetch_md(OrgId, Checksums) when is_list(Checksums),
-                             is_binary(OrgId) ->
+                                is_binary(OrgId) ->
     parallel_fetch(OrgId, Checksums).
 
 parallel_fetch(OrgId, Checksums) ->

--- a/src/s3_ops.erl
+++ b/src/s3_ops.erl
@@ -2,6 +2,7 @@
 %% ex: ts=4 sw=4 et
 %% @author Kevin Smith <kevin@opscode.com>
 %% @author Christopher Maier <cm@opscode.com>
+%% @author Seth Chisamore <schisamo@opscode.com>
 %% Copyright 2012 Opscode, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
@@ -19,16 +20,17 @@
 %% under the License.
 %%
 
-
 -module(s3_ops).
 
 -define(MAX, 5).
 -define(TIMEOUT, 5 * 1000).
+-define(CHUNKSIZE, 20). %% TODO - make this configurable
 
 -include("chef_types.hrl").
 
 -export([
-         fetch_md/2
+         fetch_md/2,
+         delete/2
         ]).
 
 -record(state, {
@@ -41,8 +43,65 @@
 
           ok = [] :: [binary()],
           missing = [] :: [binary()],
+          timeouts = 0,
           errors = 0 :: non_neg_integer()
          }).
+
+%% @doc Delete each checksummed file in S3
+delete(OrgId, Checksums) when is_list(Checksums),
+                             is_binary(OrgId) ->
+    %% we'll split our checksum list into chunks
+    %% so we don't pound the S3 store by
+    %% parallelizing ALL THE THINGS!!
+    Chunks = chunk_list(Checksums, chunk_size()),
+    %% Delete the checksums in each chunk in parrallel
+    Results = lists:map(fun(Chunk) ->
+                    parallel_delete(OrgId, Chunk)
+                end,
+                Chunks),
+    %% The results will be a list of lists so flatten it
+    FlattenedResults = lists:flatten(Results),
+    %% Process the flattened results, splitting them into success checksums,
+    %% missing checksums, timeout count and error count
+    #state{ok=Ok, missing=Missing, timeouts=Timeouts, errors=Errors} =
+        lists:foldl(fun(A, #state{ok=Ok,missing=Missing,timeouts=Timeouts,errors=Errors}=State) ->
+            case A of
+                {value, Checksum} -> State#state{ok=[Checksum|Ok]};
+                {missing, Checksum} -> State#state{missing=[Checksum|Missing]};
+                timeout -> State#state{timeouts=Timeouts + 1};
+                _Error -> State#state{errors=Errors + 1}
+            end
+        end,
+        #state{},
+        FlattenedResults
+        ),
+
+    error_logger:info_msg(
+        "Deleted ~p/~p checksums with ~p missing, ~p timeouts and ~p errors~n",
+        [length(Ok), length(Checksums), length(Missing), Timeouts, Errors]
+    ),
+    Result = {{ok, lists:sort(Ok)},
+              {missing, lists:sort(Missing)},
+              {timeout, Timeouts},
+              {error, Errors}},
+    Result.
+
+parallel_delete(OrgId, Checksums) ->
+    Bucket = chef_s3:bucket(),
+    %% We'll take advantage of Erlware's excellent ec_plists:ftmap/3 which
+    %% applies a function to a list, in parrellel, in a fault tolerant way.
+    %% The return result looks something like:
+    %%
+    %%  [{value, 1}, {value, 2}, timeout, {badmatch, ...}]
+    %%
+    ec_plists:ftmap(fun(Checksum) ->
+                    case delete_file(OrgId, Bucket, Checksum) of
+                        {ok, Checksum} -> Checksum;
+                        {Error, Checksum} -> throw({Error, Checksum})
+                    end
+                end,
+                Checksums,
+                ?TIMEOUT).
 
 %% @doc Verify that each checksummed file is stored in S3 by checking its metadata
 fetch_md(OrgId, Checksums) when is_list(Checksums),
@@ -139,3 +198,54 @@ check_file(OrgId, Bucket, Checksum) ->
                      {error, Checksum}
              end,
     Result.
+
+%% @doc Delete an existing checksum file in S3
+-spec delete_file(OrgId :: object_id(),
+                 Bucket :: string(),
+                 Checksum :: binary()) -> {'error', binary()} |
+                                          {'missing', binary()} |
+                                          {'ok', binary()}.
+delete_file(OrgId, Bucket, Checksum) ->
+    Key = chef_s3:make_key(OrgId, Checksum),
+    AwsConfig = chef_s3:get_config(),
+    Result = try mini_s3:delete_object(Bucket, Key, AwsConfig) of
+                %% Return value doesn't much matter here but it looks like, but
+                %% for documentation sake it looks like:
+                %%
+                %%  [{delete_marker, list_to_existing_atom(Marker)}, {version_id, Id}]
+                %%
+                 _Response ->
+                     {ok, Checksum}
+             catch
+                error:{aws_error, {http_error,404,_}} ->
+                     {missing, Checksum};
+                X:Y->
+                    error_logger:error_msg(
+                        "Could not delete checksum ~p from bucket ~p: Reason -> ~p:~p~n",
+                        [Checksum, Bucket, X, Y]
+                    ),
+                    {error, Checksum}
+             end,
+    Result.
+
+%% TODO - pull this from config
+chunk_size() ->
+    ?CHUNKSIZE.
+
+%% TODO: opscode_commons
+chunk_list([], _, Result) ->
+    lists:reverse(Result);
+chunk_list(List, ChunkSize, Result) ->
+    {Chunk, Rest} = safe_split(ChunkSize, List),
+    chunk_list(Rest, ChunkSize, [Chunk | Result]).
+
+chunk_list(List, ChunkSize) ->
+    chunk_list(List, ChunkSize, []).
+
+safe_split(N, L) ->
+    try
+        lists:split(N, L)
+    catch
+        error:badarg ->
+            {L, []}
+    end.

--- a/test/chef_deep_merge_test.erl
+++ b/test/chef_deep_merge_test.erl
@@ -15,7 +15,7 @@
 %% under the License.
 %%
 
--module(deep_merge_test).
+-module(chef_deep_merge_test).
 
 -include_lib("eunit/include/eunit.hrl").
 
@@ -45,7 +45,7 @@ deep_merge_comparison({MergeeFile, OtherFile, ExpectedFile}) ->
   OtherTerm    = json_read(OtherFile),
   ExpectedTerm = json_read(ExpectedFile),
   {"Deep Merge Test: " ++ TestIndex, fun() ->
-        Result = deep_merge:merge(MergeeTerm, OtherTerm),
+        Result = chef_deep_merge:merge(MergeeTerm, OtherTerm),
         NormalizedExpected = normalize(ExpectedTerm),
         NormalizedResult = normalize(Result),
         ?assertEqual(NormalizedExpected,NormalizedResult)

--- a/test/chef_s3_tests.erl
+++ b/test/chef_s3_tests.erl
@@ -109,7 +109,7 @@ url_test_() ->
         end}]}.
 
 checksum_test_() ->
-    MockedModules = [mini_s3, chef_s3, s3_ops],
+    MockedModules = [mini_s3, chef_s3, chef_s3_ops],
     {foreach,
      fun() ->
              %% Temporarily disable logging chef_s3:delete_checksums/2
@@ -119,7 +119,7 @@ checksum_test_() ->
              application:set_env(chef_objects, s3_platform_bucket_name, "testbucket"),
 
              %% Make the chunk size smaller
-             meck:expect(s3_ops, chunk_size, fun() -> 3 end),
+             meck:expect(chef_s3_ops, chunk_size, fun() -> 3 end),
 
              %% Actual value doesn't matter; we're not going to use it anyway
              meck:expect(mini_s3, new, 3, ignored),

--- a/test/chef_s3_tests.erl
+++ b/test/chef_s3_tests.erl
@@ -112,6 +112,8 @@ checksum_test_() ->
     MockedModules = [mini_s3, chef_s3, s3_ops],
     {foreach,
      fun() ->
+             %% Temporarily disable logging chef_s3:delete_checksums/2
+             error_logger:tty(false),
              test_utils:mock(MockedModules, [passthrough]),
              meck:expect(chef_s3, get_config, fun() -> mock_config end),
              application:set_env(chef_objects, s3_platform_bucket_name, "testbucket"),
@@ -186,6 +188,8 @@ checksum_test_() ->
              OrgId
      end,
      fun(_OrgId) ->
+             %% Re-enable logging
+             error_logger:tty(true),
              test_utils:unmock(MockedModules)
      end,
      [


### PR DESCRIPTION
This pull request adds the ability to delete a list of checksums on S3/Bookshelf.  The deletion is done in chunked groups with parallel deletion of the checksums within each group.
- **chef_s3:delete_checksums/2** - Given a list of checksums, chunk it into (configurable) groups and
  delete the checksums in each chunk in parallel.
- **s3_ops:delete_checksums/2** - Entry point used by codebase as a whole into S3 
  checksum deletion logic.
- additional test coverage for new logic
