### PR TITLE
Remove DbType from chef_db_compression

### DIFF
--- a/test/chef_cookbook_tests.erl
+++ b/test/chef_cookbook_tests.erl
@@ -212,12 +212,10 @@ assemble_cookbook_ejson_test_() ->
       fun() ->
               OrgId = <<"12341234123412341234123412341234">>,
               AuthzId = <<"auth">>,
-              DbType = pgsql,
               Record = chef_object:new_record(chef_cookbook_version,
                                               OrgId,
                                               AuthzId,
-                                              CBEJson,
-                                              DbType),
+                                              CBEJson),
 
               chef_test_utility:ejson_match(CBEJson,
                                             chef_cookbook:assemble_cookbook_ejson(Record)),

--- a/test/chef_db_compression_tests.erl
+++ b/test/chef_db_compression_tests.erl
@@ -24,25 +24,27 @@
 
 -define(TYPES, [chef_node, chef_role, chef_data_bag_item]).
 
-mysql_always_compressed_test_() ->
-    [ {"mysql compressed for: " ++ atom_to_list(Type),
+always_compressed_test_() ->
+    [ {"compressed for: " ++ atom_to_list(Type),
        fun() ->
-               assert_compressed(chef_db_compression:compress(mysql, Type, ?DATA))
-       end} || Type <- ?TYPES ].
-
-pgsql_sometimes_compressed_test_() ->
-    Tests = [{chef_node, fun assert_not_compressed/1},
-             {chef_role, fun assert_compressed/1},
-             {chef_data_bag_item, fun assert_compressed/1}],
-    [ fun() ->
-              Assert(chef_db_compression:compress(pgsql, Type, ?DATA))
-      end || {Type, Assert} <- Tests ].
+               assert_compressed(chef_db_compression:compress(Type, ?DATA))
+       end} || Type <- [chef_role, chef_data_bag_item] ].
 
 assert_compressed(CData) ->
     ?assert(size(CData) =/= size(?DATA)),
     ?assertNot(?DATA =:= CData),
     ?assertEqual(?DATA, chef_db_compression:decompress(CData)).
 
+-ifdef(CHEF_UNCOMPRESSED_NODE_DATA).
+sometimes_compressed_test_() ->
+    Tests = [{chef_node, fun assert_not_compressed/1},
+             {chef_role, fun assert_compressed/1},
+             {chef_data_bag_item, fun assert_compressed/1}],
+    [ fun() ->
+              Assert(chef_db_compression:compress(Type, ?DATA))
+      end || {Type, Assert} <- Tests ].
+
 assert_not_compressed(CData) ->
     ?assertEqual(?DATA, CData),
     ?assertEqual(?DATA, chef_db_compression:decompress(CData)).
+-endif.

--- a/test/chef_object_tests.erl
+++ b/test/chef_object_tests.erl
@@ -72,7 +72,6 @@ new_record_test_() ->
     AuthzId = <<"authz-123">>,
     NameJson = {[{<<"name">>, <<"the-name">>}, {<<"alpha">>, <<"bravo">>}]},
     IdJson = {[{<<"id">>, <<"the-name">>}, {<<"alpha">>, <<"bravo">>}]},
-    DbTypes = [pgsql, mysql],
     NameForInput = fun(Name) when is_binary(Name) ->
                            Name;
                       ({BagName, {ItemData}}) when is_binary(BagName) ->
@@ -92,10 +91,10 @@ new_record_test_() ->
             ],
     [ {atom_to_list(RecName),
        fun() ->
-              Got = chef_object:new_record(RecName, O, A, Data, DbType),
+              Got = chef_object:new_record(RecName, O, A, Data),
               ?assertEqual(NameForInput(Data), chef_object:name(Got)),
               ?assertEqual(32, size(chef_object:id(Got)))
-      end} || {RecName, O, A, Data} <- Tests, DbType <- DbTypes ].
+      end} || {RecName, O, A, Data} <- Tests ].
 
 %% ejson_for_indexing tests
 
@@ -220,7 +219,7 @@ data_Bag_item_update_from_ejson_test_() ->
       [
        {atom_to_list(DbType),
         fun() ->
-                Item1 = chef_object:update_from_ejson(Item, RawItem, DbType),
+                Item1 = chef_object:update_from_ejson(Item, RawItem),
                 GotData = Item1#chef_data_bag_item.serialized_object,
                 GotEjson = ejson:decode(chef_db_compression:decompress(GotData)),
                 ?assertEqual(<<"the_item_name">>, Item1#chef_data_bag_item.item_name),
@@ -239,7 +238,7 @@ environment_update_from_ejson_test_() ->
       [
        {atom_to_list(DbType),
         fun() ->
-                Env1 = chef_object:update_from_ejson(Env, RawEnv, DbType),
+                Env1 = chef_object:update_from_ejson(Env, RawEnv),
                 GotData = Env1#chef_environment.serialized_object,
                 GotEjson = ejson:decode(chef_db_compression:decompress(GotData)),
                 ?assertEqual(<<"new_name">>, Env1#chef_environment.name),
@@ -254,7 +253,7 @@ node_update_from_ejson_test_() ->
       [
        {atom_to_list(DbType),
         fun() ->
-                Node1 = chef_object:update_from_ejson(Node, RawNode, DbType),
+                Node1 = chef_object:update_from_ejson(Node, RawNode),
                 GotData = Node1#chef_node.serialized_object,
                 GotEjson = ejson:decode(chef_db_compression:decompress(GotData)),
                 ?assertEqual(<<"a_node">>, Node1#chef_node.name),
@@ -280,7 +279,7 @@ role_update_from_ejson_test_() ->
       [
        {atom_to_list(DbType),
         fun() ->
-                Role1 = chef_object:update_from_ejson(Role, RawRole, DbType),
+                Role1 = chef_object:update_from_ejson(Role, RawRole),
                 GotData = Role1#chef_role.serialized_object,
                 GotEjson = ejson:decode(chef_db_compression:decompress(GotData)),
                 ?assertEqual(<<"new_name">>, Role1#chef_role.name),


### PR DESCRIPTION
By default, all data is gzip compressed. If a schema is being used
that required uncompressed node data, then the macro
CHEF_UNCOMPRESSED_NODE_DATA should be defined at compile time.

The signatures for chef_object:new_record and
chef_object:update_from_ejson no longer take the DbType argument.

There are PRs in chef_db, and chef_wm that are required once this is merged. Also note that since the CHEF_UNCOMPRESSED_NODE_DATA macro is not defined for the OSC erchef build, this change requires a schema change to the serialized object column of the node table.

You can test this locally with:

```
alter table nodes drop serialized_object;
alter table nodes add column serialized_object bytea;
alter table nodes alter serialized_object set storage external;
```
