### PR TITLE
Add chef_role:environments/1

### DIFF
--- a/src/chef_role.erl
+++ b/src/chef_role.erl
@@ -23,6 +23,7 @@
 -module(chef_role).
 
 -export([
+         environments/1,
          parse_binary_json/2
         ]).
 
@@ -58,6 +59,13 @@
         ]).
 
 -type role_action() :: create | { update, Name::binary() }.
+
+%% @doc Given the EJSON representation of a role, return a sorted list of the environment names
+%% present in the role's `env_run_list` hash.
+-spec environments(ej:json_object()) -> [binary()].
+environments(Role) ->
+    {Items} = ej:get({<<"env_run_lists">>}, Role),
+    lists:sort([ Key || {Key, _} <- Items ]).
 
 %% @doc Convert a binary JSON string representing a Chef Role into an
 %% EJson-encoded Erlang data structure.

--- a/test/chef_role_tests.erl
+++ b/test/chef_role_tests.erl
@@ -31,8 +31,22 @@ basic_role() ->
       {<<"chef_type">>, <<"role">>},
       {<<"default_attributes">>, {[]}},
       {<<"override_attributes">>, {[]}},
-      {<<"run_list">>, []}
+      {<<"run_list">>, []},
+      {<<"env_run_lists">>, {[]}}
      ]}.
+
+
+role_environments_test_() ->
+    [{"empty env_run_lists",
+      ?_assertEqual([], chef_role:environments(basic_role()))},
+
+     {"non-empty env_run_lists",
+      fun() ->
+              Role = ej:set({<<"env_run_lists">>}, basic_role(),
+                            {[{<<"e2">>, {[]}}, {<<"e1">>, {[]}}]}),
+              ?assertEqual([<<"e1">>, <<"e2">>], chef_role:environments(Role))
+      end}
+    ].
 
 validate_role_test_() ->
     [


### PR DESCRIPTION
This function extracts the list of environments that have custom run
lists for a given role EJSON. Used by /roles/:role/environments.
