### PR TITLE
Normalize run list entries for nodes and roles

### DIFF
--- a/src/chef_node.erl
+++ b/src/chef_node.erl
@@ -27,6 +27,9 @@
          insert_autofill_fields/1,
          parse_check_binary_as_json_node/2]).
 
+-ifdef(TEST).
+-compile(export_all).
+-endif.
 
 -include("chef_types.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -120,5 +123,13 @@ parse_check_binary_as_json_node(NodeBin, Action) ->
     {ok, ValidNode} = validate_json_node(JsonFilled, Action),
     %% We validate then normalize, because the normalization code assumes there are valid
     %% entries to normalize in the first place.
-    Normalized = chef_object:normalize(node, ValidNode),
+    Normalized = normalize(ValidNode),
     {ok, Normalized}.
+
+%% @doc Normalizes the run list of an EJson Node, putting it into canonical form (all bare
+%% recipes are qualified with "recipe[...]"), and exact duplicates are removed.
+-spec normalize(ej:json_object()) -> ej:json_object().
+normalize(NodeEjson) ->
+    RunList = ej:get({<<"run_list">>}, NodeEjson, []),
+    Normalized = chef_object:normalize_runlist(RunList),
+    ej:set({<<"run_list">>}, NodeEjson, Normalized).

--- a/src/chef_node.erl
+++ b/src/chef_node.erl
@@ -131,5 +131,5 @@ parse_check_binary_as_json_node(NodeBin, Action) ->
 -spec normalize(ej:json_object()) -> ej:json_object().
 normalize(NodeEjson) ->
     RunList = ej:get({<<"run_list">>}, NodeEjson, []),
-    Normalized = chef_object:normalize_runlist(RunList),
+    Normalized = chef_object:normalize_run_list(RunList),
     ej:set({<<"run_list">>}, NodeEjson, Normalized).

--- a/src/chef_node.erl
+++ b/src/chef_node.erl
@@ -117,4 +117,8 @@ parse_check_binary_as_json_node(NodeBin, Action) ->
     %% a `throw:Why' pattern.
     Json = ejson:decode(NodeBin),
     JsonFilled = insert_autofill_fields(Json),
-    validate_json_node(JsonFilled, Action).
+    {ok, ValidNode} = validate_json_node(JsonFilled, Action),
+    %% We validate then normalize, because the normalization code assumes there are valid
+    %% entries to normalize in the first place.
+    Normalized = chef_object:normalize(node, ValidNode),
+    {ok, Normalized}.

--- a/src/chef_object.erl
+++ b/src/chef_object.erl
@@ -535,6 +535,9 @@ normalize_run_list(RunList) ->
 %% "role[...]" remain unchanged, while all other input is taken to be a recipe, and is
 %% wrapped as "recipe[ITEM]".
 %%
+%% It is assumed that only legal run list items will be input to this function (i.e., the
+%% run lists they are part of have already been validated).
+%%
 %% NOTE: About the spec here, `<<_:40,_:_*8>>` is the notation for a binary string that is
 %% at least 5 bytes long (8 bits * 5 = 40).  This comes from Dialyzer inferring that the
 %% smallest possible return value for this function would be <<"role[">>, which (while true)

--- a/src/chef_object.erl
+++ b/src/chef_object.erl
@@ -41,6 +41,11 @@
          update_from_ejson/2
         ]).
 
+%% In order to fully test things
+-ifdef(TEST).
+-compile([export_all]).
+-endif.
+
 %% @doc Create a new Chef object record of type specified by `RecType'. This function will
 %% generate a unique id for the object using `make_org_prefix_id/2'. If `AuthzId' is the
 %% atom 'unset', then the object's generated id will be used as a placeholder authorization

--- a/src/chef_object.erl
+++ b/src/chef_object.erl
@@ -33,7 +33,7 @@
          make_org_prefix_id/2,
          name/1,
          new_record/4,
-         normalize_runlist/1,
+         normalize_run_list/1,
          parse_constraint/1,
          set_created/2,
          set_updated/2,
@@ -527,8 +527,8 @@ cert_or_key(ClientData) ->
 %%
 %% Exact duplicates are removed following the normalization process.  Semantic duplicates
 %% (such as "recipe[foo]" and "recipe[foo::default]") are preserved.
--spec normalize_runlist(RunList :: [binary()]) -> [binary()].
-normalize_runlist(RunList) ->
+-spec normalize_run_list(RunList :: [binary()]) -> [binary()].
+normalize_run_list(RunList) ->
     deduplicate_run_list([normalize_item(Item) || Item <- RunList]).
 
 %% @doc Explicitly qualify a run list item.  Items already marked as "recipe[...]" or

--- a/src/chef_object.erl
+++ b/src/chef_object.erl
@@ -555,20 +555,14 @@ normalize_item(Recipe) when is_binary(Recipe) ->
 
 %% @doc Removes duplicates from a run list, preserving order.  Intended for use with
 %% already-normalized run lists.
+%% @end
 %%
 %% NOTE: The spec for this function is the way it is for the same reasons as
 %% `normalize_item/1`.  See the documentation for that function for the gory details.
+%%
+%% TODO: This would be a good candidate for a 'chef_common' module function; it's copied
+%% from chef_wm_depsolver:remove_dups/1.
 -spec deduplicate_run_list([<<_:40,_:_*8>>]) -> list().
-deduplicate_run_list(RunList) ->
-    WithoutDupes = lists:foldl(
-                     fun(Item, Deduped) ->
-                             case lists:member(Item, Deduped) of
-                                 true ->
-                                     Deduped;
-                                 false ->
-                                     [Item | Deduped]
-                             end
-                     end,
-                     [],
-                     RunList),
-    lists:reverse(WithoutDupes).
+deduplicate_run_list(L) ->
+    WithIdx = lists:zip(L, lists:seq(1, length(L))),
+    [ Elt || {Elt, _} <- lists:ukeysort(2, lists:ukeysort(1, WithIdx)) ].

--- a/src/chef_role.erl
+++ b/src/chef_role.erl
@@ -137,11 +137,11 @@ normalize(RoleEjson) ->
     EnvRunListsKey = <<"env_run_lists">>,
 
     RunList = ej:get({RunListKey}, RoleEjson, []),
-    NormalizedRunList = chef_object:normalize_runlist(RunList),
+    NormalizedRunList = chef_object:normalize_run_list(RunList),
 
     %% Roles have a hash of {environment -> run list} that need to be normalized as well.
     {EnvRunLists} = ej:get({EnvRunListsKey}, RoleEjson, ?EMPTY_EJSON_HASH),
-    NormalizedEnvRunLists = {[{Env, chef_object:normalize_runlist(List)} || {Env, List} <- EnvRunLists]},
+    NormalizedEnvRunLists = {[{Env, chef_object:normalize_run_list(List)} || {Env, List} <- EnvRunLists]},
 
     lists:foldl(fun({Key, Value}, Role) ->
                         ej:set({Key}, Role, Value)

--- a/src/chef_role.erl
+++ b/src/chef_role.erl
@@ -80,7 +80,11 @@ parse_binary_json(Bin, Action) ->
     %% parse error from ejson if we can extract it?
     Role0 = ejson:decode(Bin),
     Role = set_default_values(Role0),
-    validate_role(Role, Action).
+    {ok, ValidRole} = validate_role(Role, Action),
+    %% We validate then normalize, because the normalization code assumes there are valid
+    %% entries to normalize in the first place.
+    Normalized = chef_object:normalize(role, ValidRole),
+    {ok, Normalized}.
 
 
 %% TODO: merge set_default_values and validate_role?

--- a/src/chef_role.erl
+++ b/src/chef_role.erl
@@ -83,9 +83,8 @@ parse_binary_json(Bin, Action) ->
     {ok, ValidRole} = validate_role(Role, Action),
     %% We validate then normalize, because the normalization code assumes there are valid
     %% entries to normalize in the first place.
-    Normalized = chef_object:normalize(role, ValidRole),
+    Normalized = normalize(ValidRole),
     {ok, Normalized}.
-
 
 %% TODO: merge set_default_values and validate_role?
 
@@ -128,3 +127,25 @@ validate_role(Role, {update, UrlName}) ->
         Mismatch ->
             throw({url_json_name_mismatch, {UrlName, Mismatch, "Role"}})
     end.
+
+%% @doc Normalizes the run lists of an EJson Role.  All run lists are put into canonical
+%% form (all bare recipes are qualified with "recipe[...]"), and exact duplicates are
+%% removed.
+-spec normalize(ej:json_object()) -> ej:json_object().
+normalize(RoleEjson) ->
+    RunListKey = <<"run_list">>,
+    EnvRunListsKey = <<"env_run_lists">>,
+
+    RunList = ej:get({RunListKey}, RoleEjson, []),
+    NormalizedRunList = chef_object:normalize_runlist(RunList),
+
+    %% Roles have a hash of {environment -> run list} that need to be normalized as well.
+    {EnvRunLists} = ej:get({EnvRunListsKey}, RoleEjson, ?EMPTY_EJSON_HASH),
+    NormalizedEnvRunLists = {[{Env, chef_object:normalize_runlist(List)} || {Env, List} <- EnvRunLists]},
+
+    lists:foldl(fun({Key, Value}, Role) ->
+                        ej:set({Key}, Role, Value)
+                end,
+                RoleEjson,
+                [{RunListKey, NormalizedRunList},
+                 {EnvRunListsKey, NormalizedEnvRunLists}]).

--- a/test/chef_node_tests.erl
+++ b/test/chef_node_tests.erl
@@ -202,3 +202,14 @@ parse_check_binary_as_json_node_test_() ->
       end
      }
     ].
+
+normalize_test_() ->
+    [{"Normalizes a node's run list",
+      fun() ->
+              Input = ej:set({<<"run_list">>}, extended_node(),
+                             [<<"foo">>, <<"bar">>, <<"baz">>]),
+              Normalized = ej:set({<<"run_list">>}, extended_node(),
+                                  [<<"recipe[foo]">>, <<"recipe[bar]">>, <<"recipe[baz]">>]),
+              ?assertEqual(Normalized,
+                           chef_node:normalize(Input))
+      end}].

--- a/test/chef_node_tests.erl
+++ b/test/chef_node_tests.erl
@@ -177,5 +177,28 @@ parse_check_binary_as_json_node_test_() ->
                        chef_node:parse_check_binary_as_json_node(NB, create)),
           ?assertThrow({url_json_name_mismatch, _},
                        chef_node:parse_check_binary_as_json_node(NB, {update, <<"a_node">>}))
-      end}
+      end},
+     {"Ensure that all variants of recipes in a run list are properly normalized",
+      fun() ->
+              N = extended_node(),
+              RunList = [<<"foo">>,
+                         <<"bar::default">>,
+                         <<"baz::quux@1.0.0">>,
+                         <<"recipe[web]">>,
+                         <<"role[prod]">>],
+              WithRunList = ej:set({<<"run_list">>}, N, RunList),
+              JSON = ejson:encode(WithRunList),
+
+              %% Test for create
+              {ok, Processed} = chef_node:parse_check_binary_as_json_node(JSON, create),
+              ?assertEqual([<<"recipe[foo]">>, <<"recipe[bar::default]">>, <<"recipe[baz::quux@1.0.0]">>, <<"recipe[web]">>, <<"role[prod]">>],
+                           ej:get({<<"run_list">>}, Processed)),
+
+              %% Test for update
+              {ok, ProcessedForUpdate} = chef_node:parse_check_binary_as_json_node(JSON, {update, ej:get({<<"name">>}, N)}),
+              ?assertEqual([<<"recipe[foo]">>, <<"recipe[bar::default]">>, <<"recipe[baz::quux@1.0.0]">>, <<"recipe[web]">>, <<"role[prod]">>],
+                           ej:get({<<"run_list">>}, ProcessedForUpdate))
+
+      end
+     }
     ].

--- a/test/chef_object_tests.erl
+++ b/test/chef_object_tests.erl
@@ -464,14 +464,14 @@ normalize_item_test_() ->
                                         ]
     ].
 
-normalize_runlist_test_() ->
+normalize_run_list_test_() ->
     [{Message,
       fun() ->
               ?assertEqual(Normalized,
-                           chef_object:normalize_runlist(Input))
+                           chef_object:normalize_run_list(Input))
       end}
      || {Message, Input, Normalized} <- [
-                                         {"Normalizes an empty runlist", [], []},
+                                         {"Normalizes an empty run list", [], []},
                                          {"Does nothing to an already normalized list",
                                           [<<"recipe[foo]">>, <<"role[web]">>, <<"recipe[bar::baz]">>],
                                           [<<"recipe[foo]">>, <<"role[web]">>, <<"recipe[bar::baz]">>]},
@@ -494,6 +494,6 @@ semantic_duplication_test_() ->
               Input = [<<"foo">>, <<"foo::default">>],
               Normalized = [<<"recipe[foo]">>, <<"recipe[foo::default]">>],
               ?assertEqual(Normalized,
-                           chef_object:normalize_runlist(Input))
+                           chef_object:normalize_run_list(Input))
       end}
     ].

--- a/test/chef_object_tests.erl
+++ b/test/chef_object_tests.erl
@@ -298,6 +298,13 @@ basic_node() ->
       {<<"run_list">>, [<<"recipe[web]">>, <<"role[prod]">>]}
      ]}.
 
+basic_role() ->
+    {[{<<"name">>, <<"a_role">>},
+      {<<"description">>, <<"my awesome role">>},
+      {<<"run_list">>, [<<"recipe[web]">>, <<"role[prod]">>]},
+      {<<"env_run_lists">>, {[]}}
+     ]}.
+
 basic_node_index() ->
     {[{<<"name">>, <<"a_node">>},
       {<<"chef_type">>, <<"node">>},
@@ -408,3 +415,131 @@ make_org_id() ->
     <<TL:32, TM:16, THV:16, CSR:8, CSL:8, N:48>> = crypto:rand_bytes(16),
     Fmt = "~8.16.0b~4.16.0b~4.16.0b~2.16.0b~2.16.0b~12.16.0b",
     iolist_to_binary((io_lib:format(Fmt, [TL, TM, THV, CSR, CSL, N]))).
+
+deduplicate_run_list_test_() ->
+    [{Message,
+      fun() ->
+              ?assertEqual(Expected,
+                           chef_object:deduplicate_run_list(Input))
+      end}
+     || {Message, Input, Expected} <- [
+                                       {"'deduplicates' an empty list", [], []},
+                                       {"Leaves a list with no duplicates alone",
+                                        ["foo", "bar", "baz"],
+                                        ["foo", "bar", "baz"]},
+                                       {"Deduplicates a list that happens to be sorted already",
+                                        ["a", "a", "b", "a", "c", "c", "d"],
+                                        ["a","b","c","d"]},
+                                       {"Deduplicates an unsorted list, and retains its ordering",
+                                        ["d", "c", "c", "a", "b", "b", "a"],
+                                        ["d", "c", "a", "b"]}
+                                      ]
+    ].
+
+normalize_item_test_() ->
+    [{Message,
+     fun() ->
+             ?assertEqual(Normalized,
+                         chef_object:normalize_item(Input))
+     end}
+     || {Message, Input, Normalized} <- [
+                                         {"Explicit recipes are unchanged",
+                                          <<"recipe[foo]">>,
+                                          <<"recipe[foo]">>},
+                                         {"Roles are unchanged",
+                                          <<"role[foo]">>,
+                                          <<"role[foo]">>},
+                                         {"Bare cookbooks are tagged as recipes",
+                                          <<"foo">>,
+                                          <<"recipe[foo]">>},
+                                         {"Cookbook-qualified recipes are tagged as recipes",
+                                         <<"foo::bar">>,
+                                          <<"recipe[foo::bar]">>},
+                                         {"Versioned recipes are tagged as recipes",
+                                          <<"foo::bar@1.0.0">>,
+                                          <<"recipe[foo::bar@1.0.0]">>},
+                                         {"Actually, any binary, whether it is a valid cookbook/recipe or not, is tagged as a recipe; we currently assume valid run list items as input",
+                                         <<"23?8^3$$$%-not-valid-input">>,
+                                          <<"recipe[23?8^3$$$%-not-valid-input]">>}
+                                        ]
+    ].
+
+normalize_runlist_test_() ->
+    [{Message,
+      fun() ->
+              ?assertEqual(Normalized,
+                           chef_object:normalize_runlist(Input))
+      end}
+     || {Message, Input, Normalized} <- [
+                                         {"Normalizes an empty runlist", [], []},
+                                         {"Does nothing to an already normalized list",
+                                          [<<"recipe[foo]">>, <<"role[web]">>, <<"recipe[bar::baz]">>],
+                                          [<<"recipe[foo]">>, <<"role[web]">>, <<"recipe[bar::baz]">>]},
+                                         {"Normalizes bare cookbooks to recipes",
+                                          [<<"foo">>, <<"bar">>, <<"baz">>],
+                                          [<<"recipe[foo]">>, <<"recipe[bar]">>, <<"recipe[baz]">>]},
+                                         {"Normalizes a mix of run list items",
+                                          [<<"foo">>, <<"recipe[bar]">>, <<"baz::quux">>, <<"role[server]">>],
+                                          [<<"recipe[foo]">>, <<"recipe[bar]">>, <<"recipe[baz::quux]">>, <<"role[server]">>]},
+                                         {"Removes duplicates after normalization",
+                                          [<<"foo">>, <<"recipe[foo]">>],
+                                          [<<"recipe[foo]">>]}
+                                        ]
+    ].
+
+normalize_test_() ->
+    [{Message,
+      fun() ->
+              ?assertEqual(Normalized,
+                           chef_object:normalize(Type, Input))
+      end}
+    || {Message, Type, Input, Normalized} <- [
+                                              {"Normalizes a node's run list",
+                                               node,
+                                               ej:set({<<"run_list">>}, basic_node(), [<<"foo">>, <<"bar">>, <<"baz">>]),
+                                               ej:set({<<"run_list">>}, basic_node(), [<<"recipe[foo]">>, <<"recipe[bar]">>, <<"recipe[baz]">>])},
+                                              {"Normalizes a role's run list",
+                                               role,
+                                               ej:set({<<"run_list">>}, basic_role(), [<<"foo">>, <<"bar">>, <<"baz">>]),
+                                               ej:set({<<"run_list">>}, basic_role(), [<<"recipe[foo]">>, <<"recipe[bar]">>, <<"recipe[baz]">>])},
+                                              {"Normalizes a role's environment run lists",
+                                               role,
+                                               ej:set({<<"env_run_lists">>},
+                                                      basic_role(),
+                                                      {[{<<"prod">>, [<<"foo">>, <<"bar">>, <<"baz">>]},
+                                                        {<<"dev">>, [<<"oof">>, <<"rab">>, <<"zab">>]}]}),
+                                               ej:set({<<"env_run_lists">>},
+                                                      basic_role(),
+                                                      {[{<<"prod">>, [<<"recipe[foo]">>, <<"recipe[bar]">>, <<"recipe[baz]">>]},
+                                                        {<<"dev">>, [<<"recipe[oof]">>, <<"recipe[rab]">>, <<"recipe[zab]">>]}]})}
+                                             ]
+    ].
+
+%% Calling out this behavior on its own in case we decide to change it in the future
+semantic_duplication_test_() ->
+    [{Message,
+      fun() ->
+              ?assertEqual(Normalized,
+                           chef_object:normalize(Type, Input))
+      end}
+     || {Message, Type, Input, Normalized} <- [
+                                               {"Semantic duplicates in a node run list are preserved",
+                                                node,
+                                                ej:set({<<"run_list">>}, basic_node(), [<<"foo">>, <<"foo::default">>]),
+                                                ej:set({<<"run_list">>}, basic_node(), [<<"recipe[foo]">>, <<"recipe[foo::default]">>])},
+                                               {"Semantic duplicates in a role run list are preserved",
+                                                role,
+                                                ej:set({<<"run_list">>}, basic_role(), [<<"foo">>, <<"foo::default">>]),
+                                                ej:set({<<"run_list">>}, basic_role(), [<<"recipe[foo]">>, <<"recipe[foo::default]">>])},
+                                               {"Semantic duplicates in a role's environment run lists are preserved",
+                                                role,
+                                                ej:set({<<"env_run_lists">>},
+                                                       basic_role(),
+                                                       {[{<<"prod">>, [<<"foo">>, <<"foo::default">>]},
+                                                         {<<"dev">>, [<<"oof">>, <<"oof::default">>]}]}),
+                                                ej:set({<<"env_run_lists">>},
+                                                       basic_role(),
+                                                       {[{<<"prod">>, [<<"recipe[foo]">>, <<"recipe[foo::default]">>]},
+                                                         {<<"dev">>, [<<"recipe[oof]">>, <<"recipe[oof::default]">>]}]})}
+                                              ]
+    ].

--- a/test/chef_object_tests.erl
+++ b/test/chef_object_tests.erl
@@ -307,8 +307,13 @@ basic_node_index() ->
       {<<"run_list">>, [<<"recipe[web]">>, <<"role[prod]">>]}
      ]}.
 
+%% @doc Merge two proplists together, returning a proplist.  Treats them as dictionaries to
+%% prevent repeated keys.  Values in L2 take precedence of values in L1.
 merge({L1}, {L2}) ->
-    {L1 ++ L2}.
+    D1 = dict:from_list(L1),
+    D2 = dict:from_list(L2),
+    Merged = dict:merge(fun(_K,_V1,V2) -> V2 end, D1,D2),
+    {dict:to_list(Merged)}.
 
 to_sorted_list({L}) ->
     lists:sort(L).

--- a/test/chef_object_tests.erl
+++ b/test/chef_object_tests.erl
@@ -487,59 +487,13 @@ normalize_runlist_test_() ->
                                         ]
     ].
 
-normalize_test_() ->
-    [{Message,
-      fun() ->
-              ?assertEqual(Normalized,
-                           chef_object:normalize(Type, Input))
-      end}
-    || {Message, Type, Input, Normalized} <- [
-                                              {"Normalizes a node's run list",
-                                               node,
-                                               ej:set({<<"run_list">>}, basic_node(), [<<"foo">>, <<"bar">>, <<"baz">>]),
-                                               ej:set({<<"run_list">>}, basic_node(), [<<"recipe[foo]">>, <<"recipe[bar]">>, <<"recipe[baz]">>])},
-                                              {"Normalizes a role's run list",
-                                               role,
-                                               ej:set({<<"run_list">>}, basic_role(), [<<"foo">>, <<"bar">>, <<"baz">>]),
-                                               ej:set({<<"run_list">>}, basic_role(), [<<"recipe[foo]">>, <<"recipe[bar]">>, <<"recipe[baz]">>])},
-                                              {"Normalizes a role's environment run lists",
-                                               role,
-                                               ej:set({<<"env_run_lists">>},
-                                                      basic_role(),
-                                                      {[{<<"prod">>, [<<"foo">>, <<"bar">>, <<"baz">>]},
-                                                        {<<"dev">>, [<<"oof">>, <<"rab">>, <<"zab">>]}]}),
-                                               ej:set({<<"env_run_lists">>},
-                                                      basic_role(),
-                                                      {[{<<"prod">>, [<<"recipe[foo]">>, <<"recipe[bar]">>, <<"recipe[baz]">>]},
-                                                        {<<"dev">>, [<<"recipe[oof]">>, <<"recipe[rab]">>, <<"recipe[zab]">>]}]})}
-                                             ]
-    ].
-
 %% Calling out this behavior on its own in case we decide to change it in the future
 semantic_duplication_test_() ->
-    [{Message,
+    [{"Semantic duplicates in a node run list are preserved",
       fun() ->
+              Input = [<<"foo">>, <<"foo::default">>],
+              Normalized = [<<"recipe[foo]">>, <<"recipe[foo::default]">>],
               ?assertEqual(Normalized,
-                           chef_object:normalize(Type, Input))
+                           chef_object:normalize_runlist(Input))
       end}
-     || {Message, Type, Input, Normalized} <- [
-                                               {"Semantic duplicates in a node run list are preserved",
-                                                node,
-                                                ej:set({<<"run_list">>}, basic_node(), [<<"foo">>, <<"foo::default">>]),
-                                                ej:set({<<"run_list">>}, basic_node(), [<<"recipe[foo]">>, <<"recipe[foo::default]">>])},
-                                               {"Semantic duplicates in a role run list are preserved",
-                                                role,
-                                                ej:set({<<"run_list">>}, basic_role(), [<<"foo">>, <<"foo::default">>]),
-                                                ej:set({<<"run_list">>}, basic_role(), [<<"recipe[foo]">>, <<"recipe[foo::default]">>])},
-                                               {"Semantic duplicates in a role's environment run lists are preserved",
-                                                role,
-                                                ej:set({<<"env_run_lists">>},
-                                                       basic_role(),
-                                                       {[{<<"prod">>, [<<"foo">>, <<"foo::default">>]},
-                                                         {<<"dev">>, [<<"oof">>, <<"oof::default">>]}]}),
-                                                ej:set({<<"env_run_lists">>},
-                                                       basic_role(),
-                                                       {[{<<"prod">>, [<<"recipe[foo]">>, <<"recipe[foo::default]">>]},
-                                                         {<<"dev">>, [<<"recipe[oof]">>, <<"recipe[oof::default]">>]}]})}
-                                              ]
     ].

--- a/test/chef_role_tests.erl
+++ b/test/chef_role_tests.erl
@@ -173,3 +173,25 @@ parse_binary_json_test_() ->
       end
      }
     ].
+
+normalize_test_() ->
+    [{Message,
+      fun() ->
+              ?assertEqual(Normalized,
+                           chef_role:normalize(Input))
+      end}
+    || {Message, Input, Normalized} <- [
+                                        {"Normalizes a role's run list",
+                                         ej:set({<<"run_list">>}, basic_role(), [<<"foo">>, <<"bar">>, <<"baz">>]),
+                                         ej:set({<<"run_list">>}, basic_role(), [<<"recipe[foo]">>, <<"recipe[bar]">>, <<"recipe[baz]">>])},
+                                        {"Normalizes a role's environment run lists",
+                                         ej:set({<<"env_run_lists">>},
+                                                basic_role(),
+                                                {[{<<"prod">>, [<<"foo">>, <<"bar">>, <<"baz">>]},
+                                                  {<<"dev">>, [<<"oof">>, <<"rab">>, <<"zab">>]}]}),
+                                         ej:set({<<"env_run_lists">>},
+                                                basic_role(),
+                                                {[{<<"prod">>, [<<"recipe[foo]">>, <<"recipe[bar]">>, <<"recipe[baz]">>]},
+                                                  {<<"dev">>, [<<"recipe[oof]">>, <<"recipe[rab]">>, <<"recipe[zab]">>]}]})}
+                                       ]
+    ].


### PR DESCRIPTION
This PR allows the Erlang server to properly normalize run list entries upon the creation and update of nodes and roles.

That is, a run list entry of `"foo"`, `"foo::bar"` or `"foo::bar@1.0.0"` should be stored as `"recipe[foo]"`, `"recipe[foo::bar]"`, or `"recipe[foo::bar@1.0.0]"`, respectively.  Entries that are already presented as either `"recipe[...]"` or `"role[...]"` are unaffected.

Complete unit tests are included, and Dialyzer passes.  Pedant tests for this functionality are available in https://github.com/opscode/chef-pedant-core/pull/7 and https://github.com/opscode/chef-pedant-tests/pull/6.  These tests were written first against the Ruby server to verify the correct behavior.
