### PR TITLE
Standardize on ej:valid validation

### DIFF
--- a/include/chef_regex.hrl
+++ b/include/chef_regex.hrl
@@ -23,17 +23,18 @@
 -type regex_name() :: cookbook_name |
                       cookbook_version |
                       cookbook_version_constraint |
+                      data_bag_item_id |
+                      data_bag_name |
                       environment_name |
                       client_name |
+                      node_name |
                       qualified_recipe |
                       qualified_role |
                       recipe_name |
+                      role_name |
                       unqualified_recipe.
 
 -type re_regex() :: {re_pattern, integer(), integer(), binary()}.
 %% FIXME: This type is not yet correct
 %% I'd like to use binary() but dialyzer wants this more specific type
 -type re_msg() :: <<_:64,_:_*8>>.
-
-
-

--- a/src/chef_data_bag_item.erl
+++ b/src/chef_data_bag_item.erl
@@ -88,8 +88,10 @@ validate(DataBagItem) ->
 -spec normalized_data_bag_for_update(ej:json_object(), binary()) ->ej:json_object().
 normalized_data_bag_for_update(DataBagItem, IdFromUrl) ->
     case ej:get({<<"id">>}, DataBagItem)of
-        Id when Id =:= IdFromUrl orelse Id =:= undefined ->
+        undefined ->
             ej:set({<<"id">>}, DataBagItem, IdFromUrl);
+        IdFromUrl ->
+            DataBagItem;
         Mismatch ->
             throw({url_json_name_mismatch, {IdFromUrl, Mismatch, "DataBagItem"}})
     end.

--- a/src/chef_data_bag_item.erl
+++ b/src/chef_data_bag_item.erl
@@ -20,7 +20,6 @@
 %% under the License.
 %%
 
-
 -module(chef_data_bag_item).
 
 -export([
@@ -35,11 +34,11 @@
 
 -include("chef_types.hrl").
 
+%% Describes the valid structure of a data bag item for use with `ej:valid/2`.
 -define(VALIDATION_CONSTRAINTS,
-        [
-         {<<"id">>,             {match, "^[[:alnum:]_\:\.\-]+$"}}
-        ]).
-
+        {[
+          {<<"id">>, {string_match, chef_regex:regex_for(data_bag_item_id)}}
+         ]}).
 
 -spec add_type_and_bag(BagName :: binary(), Item :: ejson_term()) -> ejson_term().
 %% @doc Returns data bag item EJSON `Item' with keys `chef_type' and `data_bag' added.
@@ -58,39 +57,41 @@ wrap_item(BagName, ItemName, Item) ->
 
 %% @doc Convert a binary JSON string representing a Chef data_bag into an EJson-encoded
 %% Erlang data structure.
-%%
-%% @end
 -spec parse_binary_json( binary(), create | {update, binary()} ) ->
                                { ok, ejson_term() }. % or throw
 parse_binary_json(Bin, Action) ->
-    %% TODO: invalid_json will get logged by do_malformed_request, but
-    %% currently without any additional information.  Do we want to
-    %% emit the JSON we recieved (size limited) or some details of the
-    %% parse error from ejson if we can extract it?
     DataBagItem = unwrap_item(chef_json:decode(Bin)),
     validate_data_bag_item(DataBagItem, Action).
 
+-spec validate_data_bag_item(ej:json_object(), create | {update, binary()})
+                            -> {ok, ej:json_object()}.
 validate_data_bag_item(DataBagItem, create) ->
-    case chef_json_validator:validate_json_by_regex_constraints(DataBagItem,
-                                                                ?VALIDATION_CONSTRAINTS)of
-        ok -> {ok, DataBagItem};
-        Bad -> throw(Bad)
-    end;
-validate_data_bag_item(DataBagItem, {update, UrlName}) ->
-    %% For update, name in URL must match name, if provided, in JSON.  Missing name is ok
-    %% (you know the name by the URL you're hitting), but name mismatch is not.
-    case ej:get({<<"id">>}, DataBagItem) of
-        %% item JSON *must* contain id
-        Name when Name =:= UrlName;
-                  Name =:= undefined ->
-            WithName = ej:set({<<"id">>}, DataBagItem, UrlName),
-            case chef_json_validator:validate_json_by_regex_constraints(WithName,
-                                                                        ?VALIDATION_CONSTRAINTS) of
-                ok -> {ok, WithName};
-                Bad -> throw(Bad)
-            end;
+    validate(DataBagItem);
+validate_data_bag_item(DataBagItem, {update, IdFromUrl}) ->
+    validate(normalized_data_bag_for_update(DataBagItem, IdFromUrl)).
+
+%% @doc Common logic for validating a data bag item, whether it's for creation or update
+-spec validate(ej:json_object()) -> {ok, ej:json_object()}.
+validate(DataBagItem) ->
+    case ej:valid(?VALIDATION_CONSTRAINTS, DataBagItem) of
+        ok ->
+            {ok, DataBagItem};
+        Bad ->
+            throw(Bad)
+    end.
+
+%% @doc For data bag update, the id in URL must match the id (if provided) in the JSON.
+%% Missing the id is ok (you know from the URL you're hitting), but an id mismatch is not.
+%%
+%% Returns `DataBagItem` with `IdFromUrl` unambiguously set as its id, or throws if it was
+%% mismatched.
+-spec normalized_data_bag_for_update(ej:json_object(), binary()) ->ej:json_object().
+normalized_data_bag_for_update(DataBagItem, IdFromUrl) ->
+    case ej:get({<<"id">>}, DataBagItem)of
+        Id when Id =:= IdFromUrl orelse Id =:= undefined ->
+            ej:set({<<"id">>}, DataBagItem, IdFromUrl);
         Mismatch ->
-            throw({url_json_name_mismatch, {UrlName, Mismatch, "DataBagItem"}})
+            throw({url_json_name_mismatch, {IdFromUrl, Mismatch, "DataBagItem"}})
     end.
 
 unwrap_item(Ejson) ->

--- a/src/chef_environment.erl
+++ b/src/chef_environment.erl
@@ -62,22 +62,20 @@ environment_spec() ->
       {{opt, <<"description">>}, string},
       {{opt, <<"json_class">>}, <<"Chef::Environment">>},
       {{opt, <<"chef_type">>}, <<"environment">>},
-      {{opt, <<"default_attributes">>}, object},
-      {{opt, <<"override_attributes">>}, object},
-      {{opt, <<"cookbook_versions">>},
-       {object_map, {
-          {keys, {string_match,
-                  chef_regex:regex_for(cookbook_name)}},
-          {values, {any_of, {[{string_match,
-                               chef_regex:regex_for(cookbook_version_constraint)},
-                              %% This is required because a simple array_map will
-                              %% succeed with multiple entries -- only arrays of
-                              %% length one (or zero) can be valid
-                              {fun_match, {fun cookbook_version_array_test/1, array,
-                                           <<"Invalid cookbook version">>}},
-                              null], <<"Invalid cookbook version">>}}}}}}
+      {{opt, <<"default_attributes">>}, chef_json_validator:attribute_spec()},
+      {{opt, <<"override_attributes">>}, chef_json_validator:attribute_spec()},
+      {{opt, <<"cookbook_versions">>}, {object_map, {{keys, {string_match, chef_regex:regex_for(cookbook_name)}},
+                                                     {values, {any_of, {[{string_match,
+                                                                          chef_regex:regex_for(cookbook_version_constraint)},
+                                                                         %% This is required because a simple array_map will
+                                                                         %% succeed with multiple entries -- only arrays of
+                                                                         %% length one (or zero) can be valid
+                                                                         {fun_match, {fun cookbook_version_array_test/1,
+                                                                                      array,
+                                                                                      <<"Invalid cookbook version">>}},
+                                                                         null],
+                                                                        <<"Invalid cookbook version">>}}}}}}
      ]}.
-
 
 %% @doc If certain fields are missing from a Environment, fill them in with
 %% sane default values.
@@ -123,4 +121,3 @@ validate_keys([{Item, _}|Rest]) ->
         _ ->
             throw({invalid_key, Item})
     end.
-

--- a/src/chef_json_validator.erl
+++ b/src/chef_json_validator.erl
@@ -1,16 +1,6 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil -*-
 %% ex: ts=4 sw=4 et
-%% @author Marc Paradise <marc@opscode.com>
-%%
-%% Exports a function that accepts a JSON document
-%% and a list of regex field/value validators, and
-%% validates document content against the provided
-%% expressions.  Note that the compiled expressions are not
-%% cached; this is module is temporary only until a
-%% more long-term solution (which includes caching) is implemented.
-%%
-%% Most of the internal functions were factored up out of
-%% chef_node
+%% @author Christopher Maier <cm@opscode.com>
 %%
 %% Copyright 2012 Opscode, Inc. All Rights Reserved.
 %%
@@ -29,202 +19,70 @@
 %% under the License.
 %%
 
-
 -module(chef_json_validator).
 
--export([validate_json_by_regex_constraints/2]).
+-export([
+         attribute_spec/0,
+         env_run_lists_spec/0,
+         run_list_spec/0
+        ]).
 
--include("chef_types.hrl").
+-ifdef(TEST).
+-compile(export_all).
+-endif.
 
--type re_regex() :: {'re_pattern', integer(), integer(), binary()}.
+-include("chef_regex.hrl").
 
-validate_json_by_regex_constraints(Json, Constraints) ->
-    check_required_fields(Json, Constraints).
-
-%%%
-%%% check_field checks various term matches
-%%%
-
-%%%
-%%% { fieldname: binary() } checks for presence
-%%%
-check_field(Doc, Name) when is_binary(Name) ->
-    case ej:get({Name}, Doc) of
-        undefined -> {missing, Name};
-        _ -> ok
-    end;
-
-%%% Requires the key to be present and to match a regexp
-%%% { fieldname: binary,
-%%%   {'match',
-%%%    fieldre: re:compile compatible regexp}}
-%%%
-check_field(Doc, {Name,{match, Regex}}) when is_binary(Name) ->
-    case ej:get({Name}, Doc) of
-        undefined -> {missing, Name};
-        F ->
-            %% We should cache the compiled regexps somehow....
-            {ok, ReComp} = re:compile(Regex),
-            case re:run(F, ReComp) of
-                {match, _} -> ok;
-                nomatch -> {mismatch, {Name, Regex, F}}
-            end
-    end;
-%%% The key is optional, but if it is present it must match a regexp
-%%% { fieldname: binary,
-%%%   {'match_if_exists',
-%%%    fieldre: re:compile compatible regexp}}
-%%%
-check_field(Doc, {Name,{match_if_exists, Regex}}) when is_binary(Name) ->
-    case ej:get({Name}, Doc) of
-        undefined -> ok;
-        F ->
-          %%% We should cache the compiled regexps somehow....
-          {ok, ReComp} = re:compile(Regex),
-          case re:run(F, ReComp) of
-              {match, _} -> ok;
-              nomatch -> {mismatch, {Name, Regex, F}}
-          end
-    end;
-
-
-check_field(Doc, {Name, is_ejson_proplist}) ->
-    case ej:get({Name}, Doc) of
-        undefined -> {missing, Name};
-        ?EMPTY_EJSON_HASH -> ok;
-        {X} when is_list(X) ->
-            ok; % TODO Make this stricter!
-        X -> {bad_ejson_proplist, {Name, X}}
-    end;
-
-%% Checks that the given field is a list of binary strings.
+%% @doc `ej:valid/2` spec for attribute hashes.  This can be used for,
+%% e.g., a node's default, override, normal, and automatic attributes,
+%% a role's default and override attributes, etc.
 %%
-check_field(Doc, {Name, is_string_list}) ->
-    case ej:get({Name}, Doc) of
-        undefined ->
-            {missing, Name};
-        L ->
-            case is_list_of_binary(L) of
-                true ->
-                    ok;
-                false ->
-                    {bad_string_list, {Name, L}}
-            end
+%% It specifies that all keys must be strings, but lets values take on
+%% any type.
+attribute_spec() ->
+    {object_map, {{keys, string},
+                  {values, any_value}}}.
+
+%% @doc `ej:valid/2` spec for validating a run list.  This can be used
+%% for nodes and roles.
+%%
+%% Note that it is valid for a run list to be empty.
+run_list_spec() ->
+    {array_map,
+     {fun_match, {fun valid_run_list_item/1,
+                  string,
+                  <<"Invalid run list entry">>}}}.
+
+%% @doc `ej:valid/2` spec for validating an `env_run_lists` map of a role.
+%%
+%% Keys must be valid environment names, and values must be valid run
+%% lists.
+%%
+%% Note that it is valid for the map as a whole to be empty.
+env_run_lists_spec() ->
+    {object_map, {
+       {keys, {string_match, chef_regex:regex_for(environment_name)}},
+       {values, run_list_spec()}}}.
+
+%%------------------------------------------------------------------------------
+%% Private Functions
+%%------------------------------------------------------------------------------
+
+-spec valid_run_list_item(Item :: any()) -> ok | error.
+valid_run_list_item(Item) when is_binary(Item) ->
+    ItemType = item_type(Item),
+    {RegEx, _Msg} = chef_regex:regex_for(ItemType),
+    case re:run(Item, RegEx, [{capture, none}]) of
+        match -> ok;
+        nomatch -> error
     end;
+valid_run_list_item(_) ->
+    error.
 
-%% Check that the given field is a list of valid runlist entries
-check_field(Doc, {Name, is_run_list}) ->
-    case ej:get({Name}, Doc) of
-        undefined ->
-            {missing, Name};
-        L ->
-            case is_run_list(L) of
-                true ->
-                    ok;
-                false ->
-                    {bad_run_list, {Name, L}}
-            end
-    end;
-
-%% Check that a map of environment -> runlist contains valid run lists
-check_field(Doc, {Name, is_run_list_map}) ->
-    case ej:get({Name}, Doc) of
-        undefined ->
-            {missing, Name};
-        ?EMPTY_EJSON_HASH -> ok;
-        {L} ->
-            case is_env_run_lists(L) of
-                true ->
-                    ok;
-                false ->
-                    {bad_run_lists, {Name, L}}
-            end;
-        X ->
-            {bad_run_lists, {Name, X}}
-    end.
-
-%%%
-%%% Requires the key to be present and to match a regexp
-%%%
-check_required_fields(_Doc, []) -> ok;
-check_required_fields(Doc, [FieldDesc|Remaining]) ->
-    case check_field(Doc, FieldDesc) of
-        ok -> check_required_fields(Doc, Remaining);
-        X -> X
-    end.
-
-%
-
-is_list_of_binary([]) ->
-    true;
-is_list_of_binary([H|T]) when is_binary(H) ->
-    is_list_of_binary(T);
-is_list_of_binary([_|_]) ->
-    false;
-is_list_of_binary(_NotAList) ->
-    false.
-
-%% @doc Given a Chef run list (as a list of binary strings),
-%% determines if all entries are valid run list items.
--spec is_run_list([binary()]) -> boolean().
-is_run_list([]) ->
-    true;
-is_run_list([H|T]) when is_binary(H)->
-    case valid_run_list_item(H) of
-        true ->
-            is_run_list(T);
-        false ->
-            false
-    end;
-is_run_list([H|_]) when not is_binary(H) ->
-    false;
-is_run_list(_NotAList) ->
-    false.
-
-%% @doc Abstracts the actual task of matching a regular expression to
-%% a binary string.
--spec matches(binary(), re_regex()) -> boolean().
-matches(Item, Regexp) when is_binary(Item) andalso
-                          %% Wanted to write
-                          %% is_record(Regexp, re_pattern)
-                          %% but it doesn't work
-                          is_tuple(Regexp) andalso
-                          element(1, Regexp) =:= re_pattern ->
-    case re:run(binary_to_list(Item), Regexp, [{capture, none}]) of
-        match ->
-            true;
-        nomatch ->
-            false
-    end.
-
-%% @doc Given an item from a Chef run list, determines if it is
-%% syntactically correct, taking into account the various types of
-%% items that are allowed in a run list.
--spec valid_run_list_item(binary()) -> boolean().
-valid_run_list_item(<<"recipe[", _Rest/binary>> = QualifiedRecipe) ->
-    {RegExp, _Msg} = chef_regex:regex_for(qualified_recipe),
-    matches(QualifiedRecipe, RegExp);
-valid_run_list_item(<<"role[", _Rest/binary>> = Role) ->
-    {RegExp, _Msg} = chef_regex:regex_for(qualified_role),
-    matches(Role, RegExp);
-valid_run_list_item(UnqualifiedRecipe) when is_binary(UnqualifiedRecipe) ->
-    {RegExp, _Msg} = chef_regex:regex_for(unqualified_recipe),
-    matches(UnqualifiedRecipe, RegExp).
-
-%% @doc Given a list of {Env, RunList} tuples, verify that all RunLists are
-%% valid
-%% @end
-%% TODO: Validate that all environment names are valid as well
-%% (syntactically; not checking for environment existence yet)
--spec is_env_run_lists([{Env::binary(), [binary()]}]) -> boolean().
-is_env_run_lists([]) ->
-    true;
-is_env_run_lists([{Env, MaybeRunList}|T]) when is_binary(Env)->
-    case is_run_list(MaybeRunList) of
-        true ->
-            is_env_run_lists(T);
-        false ->
-            false
-    end;
-is_env_run_lists(_) ->
-    false.
+-spec item_type(binary()) -> qualified_recipe | qualified_role | unqualified_recipe.
+item_type(<<"recipe[", _Rest/binary>>) ->
+    qualified_recipe;
+item_type(<<"role[", _Rest/binary>>) ->
+    qualified_role;
+item_type(UnqualifiedRecipe) when is_binary(UnqualifiedRecipe) ->
+    unqualified_recipe.

--- a/src/chef_node.erl
+++ b/src/chef_node.erl
@@ -64,14 +64,6 @@ extract_roles(RunList) ->
     [ binary:part(Item, {0, byte_size(Item) - 1})
       || <<"role[", Item/binary>> <- RunList ].
 
-%%%
-%%% Some of this begs to be factored out into a separate file.
-%%%
-
-%%%
-%%%
-%%%
-
 validate(Node) ->
     case ej:valid(?VALIDATION_CONSTRAINTS, Node) of
         ok ->

--- a/src/chef_node.erl
+++ b/src/chef_node.erl
@@ -31,16 +31,19 @@
 -include("chef_types.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
--define(node_validation_constraints,
-        [{<<"name">>,             {match_if_exists, "^[[:alnum:]_\:\.\-]+$"}},
-         {<<"chef_environment">>, {match_if_exists, "^[[:alnum:]_\-]+$"}},
-         {<<"json_class">>,       {match_if_exists, "Chef::Node"}},
-         {<<"normal">>,           is_ejson_proplist},
-         {<<"default">>,          is_ejson_proplist},
-         {<<"override">>,         is_ejson_proplist},
-         {<<"automatic">>,        is_ejson_proplist},
-         {<<"run_list">>,         is_run_list}
-        ]).
+-define(VALIDATION_CONSTRAINTS,
+        {[{<<"name">>, {string_match, chef_regex:regex_for(node_name)}},
+          {<<"chef_environment">>, {string_match, chef_regex:regex_for(environment_name)}},
+          {<<"json_class">>, <<"Chef::Node">>},
+          {<<"chef_type">>, <<"node">>},
+
+          {<<"normal">>, chef_json_validator:attribute_spec()},
+          {<<"default">>, chef_json_validator:attribute_spec()},
+          {<<"override">>, chef_json_validator:attribute_spec()},
+          {<<"automatic">>, chef_json_validator:attribute_spec()},
+
+          {<<"run_list">>, chef_json_validator:run_list_spec()}
+         ]}).
 
 -define(create_if_missing_fields,
         [{<<"chef_environment">>, <<"_default">>},
@@ -68,7 +71,18 @@ extract_roles(RunList) ->
 %%%
 %%%
 %%%
+
+validate(Node) ->
+    case ej:valid(?VALIDATION_CONSTRAINTS, Node) of
+        ok ->
+            {ok, Node};
+        Bad ->
+            throw(Bad)
+    end.
+
 -spec validate_json_node(ejson_term(), {update, binary()} | create) -> {ok, ejson_term()}.
+validate_json_node(Node, create) ->
+    validate(Node);
 validate_json_node(Node, {update, UrlName}) ->
     %% For update, name in URL must match name, if provided, in JSON.
     %% Missing name is ok, but name mismatch is not.
@@ -76,19 +90,9 @@ validate_json_node(Node, {update, UrlName}) ->
         Name when Name =:= UrlName orelse
                   Name =:= undefined ->
             WithName = ej:set({<<"name">>}, Node, UrlName),
-            case chef_json_validator:validate_json_by_regex_constraints(WithName,
-                                                                        ?node_validation_constraints) of
-                ok -> {ok, WithName};
-                Bad -> throw(Bad)
-            end;
+            validate(WithName);
         Mismatch ->
             throw({url_json_name_mismatch, {UrlName, Mismatch, "Node"}})
-    end;
-validate_json_node(Node, create) ->
-    case chef_json_validator:validate_json_by_regex_constraints(Node,
-                                                                [<<"name">> | ?node_validation_constraints ]) of
-        ok -> {ok, Node};
-        Bad -> throw(Bad)
     end.
 
 insert_autofill_fields(JsonNode) ->

--- a/src/chef_regex.erl
+++ b/src/chef_regex.erl
@@ -57,6 +57,10 @@
 %% repository, this regular expression applies to them as well.
 -define(NAME_REGEX, "[.[:alnum:]_-]+").
 
+%% This is very similar to NAME_REGEX (differs only with the addition of ':').  This is used
+%% for data bags, data bag items, roles, and nodes.
+-define(ALTERNATIVE_NAME_REGEX, "[.[:alnum:]_\:-]+").
+
 %% Recipes can be cookbook-qualified; if not, the name is taken to be
 %% the cookbook, and the recipe is implicitly assumed to be "default".
 -define(COOKBOOK_PREFIX_REGEX, "(?:" ++ ?NAME_REGEX ++ "::)?").
@@ -85,10 +89,26 @@ regex_for(environment_name) ->
     {ok, Regex} = re:compile(Pattern),
     {Regex, <<"Malformed environment name. Must only contain A-Z, a-z, 0-9, _ or -">>};
 regex_for(client_name) ->
-    % This might be the same as nodename -- nodename seems to allow ':' as well
     Pattern = ?ANCHOR_REGEX(?NAME_REGEX),
     {ok, Regex} = re:compile(Pattern),
     {Regex, <<"Malformed client name.  Must be A-Z, a-z, 0-9, _, -, or .">>};
+
+regex_for(data_bag_name) ->
+    Pattern = ?ANCHOR_REGEX(?ALTERNATIVE_NAME_REGEX),
+    {ok, Regex} = re:compile(Pattern),
+    {Regex, <<"Malformed data bag name.  Must only contain A-Z, a-z, 0-9, _, :, ., or -">>};
+regex_for(data_bag_item_id) ->
+    Pattern = ?ANCHOR_REGEX(?ALTERNATIVE_NAME_REGEX),
+    {ok, Regex} = re:compile(Pattern),
+    {Regex, <<"Malformed data bag item ID.  Must only contain A-Z, a-z, 0-9, _, :, ., or -">>};
+regex_for(role_name) ->
+    Pattern = ?ANCHOR_REGEX(?ALTERNATIVE_NAME_REGEX),
+    {ok, Regex} = re:compile(Pattern),
+    {Regex, <<"Malformed role name.  Must only contain A-Z, a-z, 0-9, _, :, ., or -">>};
+regex_for(node_name) ->
+    Pattern = ?ANCHOR_REGEX(?ALTERNATIVE_NAME_REGEX),
+    {ok, Regex} = re:compile(Pattern),
+    {Regex, <<"Malformed node name.  Must only contain A-Z, a-z, 0-9, _, :, ., or -">>};
 
 %% used in environments
 regex_for(cookbook_version_constraint) ->

--- a/test/chef_data_bag_item_tests.erl
+++ b/test/chef_data_bag_item_tests.erl
@@ -1,0 +1,46 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92-*-
+%% ex: ts=4 sw=4 et
+%% @author Christopher Maier <cm@lambda.local>
+%% @copyright 2012
+
+-module(chef_data_bag_item_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("ej/include/ej.hrl").
+
+validate_data_bag_item_test_() ->
+    [
+     {Message,
+      fun() ->
+              Actual = fun() ->
+                               chef_data_bag_item:validate(EJson)
+                       end,
+              case ShouldSucceed of
+                  true ->
+                      ?assertEqual({ok, EJson}, Actual());
+                  false ->
+                      ?assertThrow(#ej_invalid{}, Actual())
+              end
+      end
+     } || {Message, EJson, ShouldSucceed} <-
+              [{<<"Data bag item with bad id '", Id/binary, "' fails">>,
+                {[{<<"id">>, Id},
+                  {<<"foo">>, <<"bar">>},
+                  {<<"baz">>, 123}]},
+                false}
+               || Id <- [<<"$$$">>,
+                         <<"foo@#)">>]]
+
+              ++ [{<<"Data bag item with good id '", Id/binary, "' succeeds">>,
+                   {[{<<"id">>, Id},
+                     {<<"foo">>, <<"bar">>},
+                     {<<"baz">>, 123}]},
+                   true}
+                  || Id <- [<<"foo">>,
+                            <<"foo.bar">>,
+                              <<"foo-bar">>,
+                            <<"foo:bar">>,
+                            <<"foo_bar">>,
+                            <<"foo-123-bar">>,
+                            <<"FOO">>]]
+    ].

--- a/test/chef_data_bag_tests.erl
+++ b/test/chef_data_bag_tests.erl
@@ -1,0 +1,75 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92-*-
+%% ex: ts=4 sw=4 et
+%% @author Christopher Maier <cm@opscode.com>
+%% @copyright 2012
+
+-module(chef_data_bag_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("ej/include/ej.hrl").
+
+validate_data_bag_test_() ->
+    [
+     {Message,
+      fun() ->
+              Actual = fun() ->
+                               chef_data_bag:validate_data_bag(EJson)
+                       end,
+              case ShouldSucceed of
+                  true ->
+                      ?assertEqual({ok, EJson}, Actual());
+                  false ->
+                      ?assertThrow(#ej_invalid{}, Actual())
+              end
+      end
+     } || {Message, EJson, ShouldSucceed} <-
+              [
+               {"Normal data bag succeeds",
+                {[{<<"name">>, <<"foo">>},
+                  {<<"chef_type">>, <<"data_bag">>},
+                  {<<"json_class">>, <<"Chef::DataBag">>}]},
+                true},
+               {"Data bag without 'json_class' succeeds",
+                {[{<<"name">>, <<"foo">>},
+                  {<<"chef_type">>, <<"data_bag">>}]},
+                true},
+               {"Data bag with 'wrong' 'json_class' succeeds",
+                {[{<<"name">>, <<"foo">>},
+                  {<<"chef_type">>, <<"data_bag">>},
+                  {<<"json_class">>, <<"Chef::Node">>}]},
+                true},
+               {"Data bag without 'chef_type' succeds",
+                {[{<<"name">>, <<"foo">>},
+                  {<<"json_class">>, <<"Chef::DataBag">>}]},
+                true},
+               {"Data bag with 'wrong' 'chef_type' succeeds",
+                {[{<<"name">>, <<"foo">>},
+                  {<<"chef_type">>, <<"node">>},
+                  {<<"json_class">>, <<"Chef::DataBag">>}]},
+                true},
+               {"Data bag with just a name succeeds",
+                {[{<<"name">>, <<"foo">>}]},
+                true},
+               {"Data bag with extra fields succeeds",
+                {[{<<"name">>, <<"foo">>},
+                  {<<"blahblah">>,<<"blahblahblah">>}]},
+                true}
+              ]
+
+              ++ [{<<"Data bag with bad name '", Name/binary, "' fails">>,
+                   {[{<<"name">>, Name}]},
+                   false}
+                  || Name <- [<<"$$$">>,
+                              <<"foo@#)">>]]
+
+              ++ [{<<"Data bag with good name '", Name/binary, "' succeeds">>,
+                   {[{<<"name">>, Name}]},
+                   true}
+                  || Name <- [<<"foo">>,
+                              <<"foo.bar">>,
+                              <<"foo-bar">>,
+                              <<"foo:bar">>,
+                              <<"foo_bar">>,
+                              <<"foo-123-bar">>,
+                              <<"FOO">>]]
+    ].

--- a/test/chef_depsolver_tests.erl
+++ b/test/chef_depsolver_tests.erl
@@ -42,21 +42,19 @@ validate_body_test_() ->
       fun() ->
               R = ej:set({<<"run_list">>}, empty_runlist(),
                          [<<"recipe[foo]">>, <<"fake[not_good]">>]),
-              ?assertThrow(#ej_invalid{type=array_elt, key= <<"run_list">>},
+              ?assertThrow(#ej_invalid{},
                            chef_depsolver:validate_body(R))
       end},
      {"Validate that a run list that is not a list is rejected",
       fun() ->
               R = ej:set({<<"run_list">>}, empty_runlist(), 12),
-              ?assertThrow(#ej_invalid{type=json_type, key= <<"run_list">>,
-                                      found_type=number, expected_type=array},
+              ?assertThrow(#ej_invalid{},
                            chef_depsolver:validate_body(R))
       end},
      {"Validate that a run list with wrong type is rejected",
       fun() ->
               R = ej:set({<<"run_list">>}, empty_runlist(), [12]),
-              ?assertThrow(#ej_invalid{type=array_elt, key= <<"run_list">>,
-                                       found_type=number, expected_type=string},
+              ?assertThrow(#ej_invalid{},
                            chef_depsolver:validate_body(R))
       end}
     ].
@@ -215,4 +213,3 @@ depsolver_complex_dependency_test() ->
     %% Check the culprits
     {error, [{_Paths, Culprits}] } = Ret,
     ?assertEqual(Expected, Culprits).
-

--- a/test/chef_json_validator_tests.erl
+++ b/test/chef_json_validator_tests.erl
@@ -23,146 +23,77 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
-%% Helper macro for validating plain old lists as run lists
--define(RUN_LIST(L), chef_json_validator:validate_json_by_regex_constraints(
-                       [{<<"run_list">>, L}],
-                       [{<<"run_list">>, is_run_list}]
-                      )).
-
-%% Helper macro for validating env_run_lists maps
--define(ENV_RUN_LIST(E), chef_json_validator:validate_json_by_regex_constraints(
-                           [{<<"env_run_lists">>, E}],
-                           [{<<"env_run_lists">>, is_run_list_map}]
-                          )).
-
-valid_run_list_test_() ->
+valid_run_list_item_test_() ->
     [
      {"Ensure that run list items are properly validated",
       fun() ->
-              %% Empty list is valid
-              ?assertEqual(ok, ?RUN_LIST([])),
+              %% Empty list is not a valid item
+              ?assertEqual(error, chef_json_validator:valid_run_list_item([])),
 
-              %% Needs to be a list of binaries, though
-              ?assertMatch({bad_run_list, _}, ?RUN_LIST("FOO")),
+              %% String isn't valid
+              ?assertMatch(error, chef_json_validator:valid_run_list_item("FOO")),
 
-              %% Not a list
-              ?assertMatch({bad_run_list, _}, ?RUN_LIST(<<"recipe[foo], recipe[bar]">>)),
-
-              %% item not binary
-              ?assertMatch({bad_run_list, _}, ?RUN_LIST(["FOO"])),
+              %% Not an item
+              ?assertMatch(error, chef_json_validator:valid_run_list_item(<<"recipe[foo], recipe[bar]">>)),
 
               % Not a binary item (obviously)
-              ?assertMatch({bad_run_list, _}, ?RUN_LIST([123])),
+              ?assertMatch(error, chef_json_validator:valid_run_list_item(123)),
 
               %% the most basic case should work
-              ?assertEqual(ok, ?RUN_LIST([<<"recipe[foo]">>])),
-
-              %% One rotten apple spoils the bunch
-              ?assertMatch({bad_run_list, _}, ?RUN_LIST([<<"recipe[foo]">>, "BAD"])),
+              ?assertEqual(ok, chef_json_validator:valid_run_list_item(<<"recipe[foo]">>)),
 
               %% Missing the closing bracket is a no-no
-              ?assertMatch({bad_run_list, _}, ?RUN_LIST([<<"recipe[foo">>])),
+              ?assertMatch(error, chef_json_validator:valid_run_list_item(<<"recipe[foo">>)),
 
-              ?assertEqual(ok, ?RUN_LIST([<<"recipe[_thing]">>])),
-              ?assertEqual(ok, ?RUN_LIST([<<"recipe[666-recipe-of-the-beast]">>])),
-              ?assertEqual(ok, ?RUN_LIST([<<"recipe[this_is_valid]">>])),
-              ?assertEqual(ok, ?RUN_LIST([<<"recipe[this_is_a_123_thing]">>])),
-              ?assertEqual(ok, ?RUN_LIST([<<"recipe[this-also-works]">>])),
+              ?assertEqual(ok, chef_json_validator:valid_run_list_item(<<"recipe[_thing]">>)),
+              ?assertEqual(ok, chef_json_validator:valid_run_list_item(<<"recipe[666-recipe-of-the-beast]">>)),
+              ?assertEqual(ok, chef_json_validator:valid_run_list_item(<<"recipe[this_is_valid]">>)),
+              ?assertEqual(ok, chef_json_validator:valid_run_list_item(<<"recipe[this_is_a_123_thing]">>)),
+              ?assertEqual(ok, chef_json_validator:valid_run_list_item(<<"recipe[this-also-works]">>)),
 
-              ?assertEqual(ok, ?RUN_LIST([<<"recipe[webserver@1.0.0]">>])),
-              ?assertEqual(ok, ?RUN_LIST([<<"recipe[webserver@1.0]">>])),
+              ?assertEqual(ok, chef_json_validator:valid_run_list_item(<<"recipe[webserver@1.0.0]">>)),
+              ?assertEqual(ok, chef_json_validator:valid_run_list_item(<<"recipe[webserver@1.0]">>)),
 
               %% Versions for a recipe must be MAJOR.MINOR or MAJOR.MINOR.PATCH
-              ?assertMatch({bad_run_list, _}, ?RUN_LIST([<<"recipe[webserver@1]">>])),
-              ?assertMatch({bad_run_list, _}, ?RUN_LIST([<<"recipe[webserver@1.0.0.0]">>])),
-              ?assertMatch({bad_run_list, _}, ?RUN_LIST([<<"recipe[webserver@1.2.foo]">>])),
-              ?assertMatch({bad_run_list, _}, ?RUN_LIST([<<"recipe[webserver@1e0e0]">>])),
-              ?assertMatch({bad_run_list, _}, ?RUN_LIST([<<"recipe[webserver@1.0e0]">>])),
-              ?assertMatch({bad_run_list, _}, ?RUN_LIST([<<"recipe[webserver@1e0.0]">>])),
-              ?assertMatch({bad_run_list, _}, ?RUN_LIST([<<"recipe[webserver@1..0.0]">>])),
-              ?assertMatch({bad_run_list, _}, ?RUN_LIST([<<"recipe[webserver@1.0..0]">>])),
+              ?assertMatch(error, chef_json_validator:valid_run_list_item(<<"recipe[webserver@1]">>)),
+              ?assertMatch(error, chef_json_validator:valid_run_list_item(<<"recipe[webserver@1.0.0.0]">>)),
+              ?assertMatch(error, chef_json_validator:valid_run_list_item(<<"recipe[webserver@1.2.foo]">>)),
+              ?assertMatch(error, chef_json_validator:valid_run_list_item(<<"recipe[webserver@1e0e0]">>)),
+              ?assertMatch(error, chef_json_validator:valid_run_list_item(<<"recipe[webserver@1.0e0]">>)),
+              ?assertMatch(error, chef_json_validator:valid_run_list_item(<<"recipe[webserver@1e0.0]">>)),
+              ?assertMatch(error, chef_json_validator:valid_run_list_item(<<"recipe[webserver@1..0.0]">>)),
+              ?assertMatch(error, chef_json_validator:valid_run_list_item(<<"recipe[webserver@1.0..0]">>)),
 
-              ?assertEqual(ok, ?RUN_LIST([<<"recipe[webserver::foo@1.0.0]">>])),
+              ?assertEqual(ok, chef_json_validator:valid_run_list_item(<<"recipe[webserver::foo@1.0.0]">>)),
 
               %% Illegal characters in recipe/role name
-              ?assertMatch({bad_run_list, _}, ?RUN_LIST([<<"recipe[aaa%b]">>])),
-              ?assertMatch({bad_run_list, _}, ?RUN_LIST([<<"recipe[aaa b]">>])),
-              ?assertMatch({bad_run_list, _}, ?RUN_LIST([<<"recipe[aaa\tb]">>])),
-              ?assertMatch({bad_run_list, _}, ?RUN_LIST([<<"recipe[aaa\nb]">>])),
-              ?assertMatch({bad_run_list, _}, ?RUN_LIST([<<"recipe[aaa()b]">>])),
-              ?assertMatch({bad_run_list, _}, ?RUN_LIST([<<"recipe[aaa=b]">>])),
+              ?assertMatch(error, chef_json_validator:valid_run_list_item(<<"recipe[aaa%b]">>)),
+              ?assertMatch(error, chef_json_validator:valid_run_list_item(<<"recipe[aaa b]">>)),
+              ?assertMatch(error, chef_json_validator:valid_run_list_item(<<"recipe[aaa\tb]">>)),
+              ?assertMatch(error, chef_json_validator:valid_run_list_item(<<"recipe[aaa\nb]">>)),
+              ?assertMatch(error, chef_json_validator:valid_run_list_item(<<"recipe[aaa()b]">>)),
+              ?assertMatch(error, chef_json_validator:valid_run_list_item(<<"recipe[aaa=b]">>)),
 
               %% Various pathological cases
-              ?assertMatch({bad_run_list, _}, ?RUN_LIST([<<"recipe[]">>])),
-              ?assertMatch({bad_run_list, _}, ?RUN_LIST([<<"recipe[Bl@a@]">>])),
+              ?assertMatch(error, chef_json_validator:valid_run_list_item(<<"recipe[]">>)),
+              ?assertMatch(error, chef_json_validator:valid_run_list_item(<<"recipe[Bl@a@]">>)),
 
               %% Role tests
-              ?assertEqual(ok, ?RUN_LIST([<<"role[foo]">>])),
-              ?assertMatch({bad_run_list, _}, ?RUN_LIST([<<"role[foo@123]">>])),
+              ?assertEqual(ok, chef_json_validator:valid_run_list_item(<<"role[foo]">>)),
+              ?assertMatch(error, chef_json_validator:valid_run_list_item(<<"role[foo@123]">>)),
 
-              ?assertEqual(ok, ?RUN_LIST([<<"role[123foo]">>])),
+              ?assertEqual(ok, chef_json_validator:valid_run_list_item(<<"role[123foo]">>)),
 
-              ?assertMatch({bad_run_list, _}, ?RUN_LIST([<<"role[foo@1.0]">>])),
-              ?assertMatch({bad_run_list, _}, ?RUN_LIST([<<"role[foobar::foo]">>])),
+              ?assertMatch(error, chef_json_validator:valid_run_list_item(<<"role[foo@1.0]">>)),
+              ?assertMatch(error, chef_json_validator:valid_run_list_item(<<"role[foobar::foo]">>)),
 
               %% Dots are OK
-              ?assertMatch(ok, ?RUN_LIST([<<"role[dots.I.haz.them]">>])),
+              ?assertMatch(ok, chef_json_validator:valid_run_list_item(<<"role[dots.I.haz.them]">>)),
 
               %% Unqualified recipe tests
-              ?assertEqual(ok, ?RUN_LIST([<<"foo">>])),
-              ?assertEqual(ok, ?RUN_LIST([<<"_foo">>])),
-              ?assertEqual(ok, ?RUN_LIST([<<"foo@1.0">>])),
-              ?assertMatch(ok, ?RUN_LIST([<<"dots.i.haz.them">>])),
-
-              %% This shouldn't work
-              %% See https://tickets.corp.opscode.com/browse/ESPRINT-913
-              ?assertMatch({bad_run_list, _}, ?RUN_LIST([<<"recipe[foo], recipe[bar]">>])),
-
-              %% VALIDATE ALL THE THINGS!
-              ?assertEqual(ok, ?RUN_LIST([
-                                          <<"recipe[foo]">>,
-                                          <<"recipe[webserver::foo]">>,
-                                          <<"recipe[webserver::foo@1.0]">>,
-                                          <<"recipe[awesomesauce::foo@001.234.82]">>,
-                                          <<"role[app_server]">>,
-                                          <<"role[other-server]">>,
-                                          <<"monitoring">>,
-                                          <<"monitoring::default">>,
-                                          <<"monitoring::alerts@1.3.4">>,
-                                          <<"website.com::base">>,
-                                          <<"website.com">>,
-                                          <<"recipe[website.com::base@1.2.3]">>,
-                                          <<"recipe[website.com]">>
-                                        ]))
+              ?assertEqual(ok, chef_json_validator:valid_run_list_item(<<"foo">>)),
+              ?assertEqual(ok, chef_json_validator:valid_run_list_item(<<"_foo">>)),
+              ?assertEqual(ok, chef_json_validator:valid_run_list_item(<<"foo@1.0">>)),
+              ?assertMatch(ok, chef_json_validator:valid_run_list_item(<<"dots.i.haz.them">>))
       end}
     ].
-
-%% This is not an exhaustive test, as all the run_list validation
-%% details are tested above
-valid_env_run_list_test_() ->
-    [{"Ensure that env_run_lists are all valid",
-     fun () ->
-             %% Empty env_run_lists is valid
-             ?assertEqual(ok, ?ENV_RUN_LIST({[]})),
-
-             %% Must be an ejson map
-             ?assertMatch({bad_run_lists, _}, ?ENV_RUN_LIST([])),
-
-             %% Valid map is valid
-             ?assertMatch(ok,
-                          ?ENV_RUN_LIST({[{<<"foo">>, [<<"recipe[foo]">>,
-                                                       <<"blah">>,
-                                                       <<"role[server]">>]},
-                                          {<<"bar">>, [<<"webserver">>,
-                                                       <<"role[base]">>]}
-                                         ]})),
-
-             %% Invalid map is invalid
-             ?assertMatch({bad_run_lists, _},
-                          ?ENV_RUN_LIST({[{<<"foo">>, [<<"recipe[foo]">>,
-                                                       <<"blah">>,
-                                                       <<"role[server]">>]},
-                                          {<<"bar">>, [<<"webserver">>,
-                                                       <<"fake[not_good]">>]}
-                                         ]}))
-     end}].

--- a/test/chef_role_tests.erl
+++ b/test/chef_role_tests.erl
@@ -22,6 +22,7 @@
 -module(chef_role_tests).
 
 -include_lib("eunit/include/eunit.hrl").
+-include_lib("ej/include/ej.hrl").
 
 basic_role() ->
     {[
@@ -62,26 +63,33 @@ validate_role_test_() ->
      {"Validate that a role with a missing name is rejected",
       fun() ->
               R = ej:delete({<<"name">>}, basic_role()),
-              ?assertThrow({missing, <<"name">>},
+              ?assertThrow(#ej_invalid{},
                            chef_role:validate_role(R, create))
       end},
      {"Validate that a chef_type not equal to 'role' is rejected",
       fun() ->
               R = ej:set({<<"chef_type">>}, basic_role(), <<"BLAHBLAH">>),
-              ?assertThrow({mismatch, {<<"chef_type">>, "role", <<"BLAHBLAH">>}},
+              ?assertThrow(#ej_invalid{},
                            chef_role:validate_role(R, create))
       end},
      {"Validate that a json_class not equal to 'Chef::Role' is rejected",
       fun() ->
               R = ej:set({<<"json_class">>}, basic_role(), <<"BLAHBLAH">>),
-              ?assertThrow({mismatch, {<<"json_class">>, "Chef::Role", <<"BLAHBLAH">>}},
+              ?assertThrow(#ej_invalid{},
                            chef_role:validate_role(R, create))
       end},
+     {"Validate that a default_attributes that is not a proplist is rejected",
+      fun() ->
+              R = ej:set({<<"default_attributes">>}, basic_role(), <<"BLAHBLAH">>),
+              ?assertThrow(#ej_invalid{},
+                           chef_role:validate_role(R, create))
+      end},
+
      {"Validate that a bogus run list is rejected",
       fun() ->
               R = ej:set({<<"run_list">>}, basic_role(),
                          [<<"recipe[foo]">>, <<"fake[not_good]">>]),
-              ?assertThrow({bad_run_list, _},
+              ?assertThrow(#ej_invalid{},
                            chef_role:validate_role(R, create))
       end},
      {"Validate that a bogus env_run_lists entry is rejected",
@@ -89,7 +97,7 @@ validate_role_test_() ->
               R = ej:set({<<"env_run_lists">>}, basic_role(),
                          {[{<<"preprod">>, [<<"recipe[foo]">>]},
                            {<<"prod">>, [<<"fake[not_good]">>]}]}),
-              ?assertThrow({bad_run_lists, _},
+              ?assertThrow(#ej_invalid{},
                            chef_role:validate_role(R, create))
       end}
     ].

--- a/test/chef_sandbox_tests.erl
+++ b/test/chef_sandbox_tests.erl
@@ -22,20 +22,23 @@
 -module(chef_sandbox_tests).
 
 -include_lib("eunit/include/eunit.hrl").
+-include_lib("ej/include/ej.hrl").
 
 validate_sandbox_test_() ->
     [
      {"Sandboxes must not be empty",
       fun() ->
               Box = {[{<<"checksums">>, {[]}}]},
-              ?assertThrow({empty_checksums, <<"A sandbox must contain at least one checksum">>},
-                           chef_sandbox:validate_sandbox(Box, create))
+              ?assertThrow(#ej_invalid{type=fun_match,
+                                       key = <<"checksums">>,
+                                       msg = <<"Bad checksums!">>},
+                           chef_sandbox:validate(Box))
       end},
 
      {"Valid sandbox is ok",
       fun() ->
               Box = {[{<<"checksums">>, {make_checksums(5)}}]},
-              ?assertEqual({ok, Box}, chef_sandbox:validate_sandbox(Box, create))
+              ?assertEqual({ok, Box}, chef_sandbox:validate(Box))
       end},
 
      {"Bad checksums are not Valid", generator,
@@ -55,8 +58,10 @@ validate_sandbox_test_() ->
                          end,
               Examples = [ {[{<<"checksums">>, MakeSums(Pos, Bad)}]} ||
                              Pos <- Locs, Bad <- BadSums ],
-              [ ?_assertThrow({bad_checksum, <<"Invalid checksum in sandbox.">>},
-                              chef_sandbox:validate_sandbox(Box, create))
+              [ ?_assertThrow(#ej_invalid{type=fun_match,
+                                          key = <<"checksums">>,
+                                          msg = <<"Bad checksums!">>},
+                              chef_sandbox:validate(Box))
                 || Box <- Examples ]
       end},
 
@@ -69,8 +74,10 @@ validate_sandbox_test_() ->
                       {[{C2, null}, {C3, null}, {C1, true}]}
                      ],
               Examples = [ {[{<<"checksums">>, E}]} || E <- Sums ],
-              [ ?_assertThrow({bad_checksum, <<"Invalid checksum in sandbox.">>},
-                              chef_sandbox:validate_sandbox(Box, create))
+              [ ?_assertThrow(#ej_invalid{type=fun_match,
+                                          key = <<"checksums">>,
+                                          msg = <<"Bad checksums!">>},
+                              chef_sandbox:validate(Box))
                 || Box <-  Examples ]
       end}
     ].


### PR DESCRIPTION
This PR makes use of `ej:valid` validation everywhere.  It also removes quite a bit of now-dead code.

These PRs are required for full effect:
- https://github.com/opscode/chef_wm/pull/21
- https://github.com/opscode/chef-pedant-core/pull/10
- https://github.com/opscode/chef-pedant-tests/pull/8
