### PR TITLE
OC-5211 Validate Public Key for Clients and Users

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 DEPS=$(CURDIR)/deps
-DIALYZER_DEPS = deps/depsolver/ebin \
+DIALYZER_DEPS = deps/chef_authn/ebin \
+                deps/depsolver/ebin \
                 deps/ej/ebin \
                 deps/jiffy/ebin \
                 deps/ibrowse/ebin \

--- a/rebar.config
+++ b/rebar.config
@@ -16,7 +16,9 @@
         {depsolver, ".*",
          {git, "git://github.com/opscode/depsolver.git", {branch, "master"}}},
         {erlware_commons, ".*",
-         {git, "git://github.com/erlware/erlware_commons.git", {tag, "v0.8.2"}}}
+         {git, "git://github.com/erlware/erlware_commons.git", {tag, "v0.8.2"}}},
+        {chef_authn, ".*",
+         {git, "git://github.com/opscode/chef_authn.git", {branch, "master"}}}
        ]}.
 
 {cover_enabled, true}.

--- a/src/chef_client.erl
+++ b/src/chef_client.erl
@@ -138,7 +138,7 @@ osc_parse_binary_json(Bin, ReqName) ->
 %% EJson-encoded Erlang data structure, using passed defaults
 %% @end
 osc_parse_binary_json(Bin, ReqName, CurrentClient) ->
-    Client = osc_set_values_from_current_client(chef_json:decode_body(Bin), CurrentClient),
+    Client = osc_set_values_from_current_client(chef_object:delete_null_public_key(chef_json:decode_body(Bin)), CurrentClient),
     Client1 = set_default_values(Client, ?DEFAULT_FIELD_VALUES),
     {Name, FinalClient} = osc_destination_name(Client1, ReqName),
     valid_name(Name),

--- a/src/chef_client.erl
+++ b/src/chef_client.erl
@@ -212,7 +212,8 @@ osc_client_spec(Name) ->
       {{opt, <<"validator">>}, boolean},
       {{opt, <<"private_key">>}, boolean},
       {{opt, <<"json_class">>}, <<"Chef::ApiClient">>},
-      {{opt, <<"chef_type">>}, <<"client">>}
+      {{opt, <<"chef_type">>}, <<"client">>},
+      {{opt, <<"public_key">>}, {fun_match, {fun chef_object:valid_public_key/1, string, <<"Public Key must be a valid key.">>}}}
      ]}.
 
 oc_client_spec(Name) ->

--- a/src/chef_object.erl
+++ b/src/chef_object.erl
@@ -709,3 +709,12 @@ key_version(<<"-----BEGIN PUBLIC KEY", _Bin/binary>>) ->
 key_version(<<"-----BEGIN RSA PUBLIC KEY", _Bin/binary>>) ->
     %% PKCS1
     ?KEY_VERSION.
+
+%% OSC will only accept public keys. It will not accept certificates
+-spec has_public_key_header(<<_:64,_:_*8>>) -> true | false.
+has_public_key_header(<<"-----BEGIN PUBLIC KEY", _/binary>>) ->
+    true;
+has_public_key_header(<<"-----BEGIN RSA PUBLIC KEY", _/binary>>) ->
+    true;
+has_public_key_header(_) ->
+    false.

--- a/src/chef_object.erl
+++ b/src/chef_object.erl
@@ -756,7 +756,7 @@ has_public_key_header(_) ->
 valid_public_key(PublicKey) ->
     case has_public_key_header(PublicKey) of
         true ->
-            case chef_authn:extract_public_or_private_key(PublicKey) of
+            case chef_authn:extract_public_key(PublicKey) of
                 {error, bad_key} ->
                     error;
                 _ ->

--- a/src/chef_user.erl
+++ b/src/chef_user.erl
@@ -78,7 +78,7 @@ parse_binary_json(Bin) ->
 
 -spec parse_binary_json(binary(), create | update) -> {ok, ej:json_object()}. % or throw
 parse_binary_json(Bin, Operation) ->
-  User = chef_json:decode(Bin),
+  User = chef_object:delete_null_public_key(chef_json:decode(Bin)),
   %% If user is invalid, an error is thown
   validate_user(User, user_spec(Operation)),
   %% Set default values after validating input, so admin can be set to false

--- a/src/chef_user.erl
+++ b/src/chef_user.erl
@@ -44,7 +44,7 @@ user_spec(create) ->
     {<<"name">>, {string_match, chef_regex:regex_for(user_name)}},
     {<<"password">>, {fun_match, {fun valid_password/1, string, <<"Password must have at least 6 characters">>}}},
     {{opt,<<"admin">>}, boolean},
-    {{opt,<<"public_key">>}, {fun_match, {fun valid_public_key/1, string, <<"Public Key must be a valid key.">>}}}
+    {{opt,<<"public_key">>}, {fun_match, {fun chef_object:valid_public_key/1, string, <<"Public Key must be a valid key.">>}}}
    ]};
 user_spec(update) ->
   {[
@@ -52,7 +52,7 @@ user_spec(update) ->
     {{opt,<<"password">>}, {fun_match, {fun valid_password/1, string, <<"Password must have at least 6 characters">>}}},
     {{opt,<<"private_key">>}, boolean},
     {{opt,<<"admin">>}, boolean},
-    {{opt,<<"public_key">>}, {fun_match, {fun valid_public_key/1, string, <<"Public Key must be a valid key.">>}}}
+    {{opt,<<"public_key">>}, {fun_match, {fun chef_object:valid_public_key/1, string, <<"Public Key must be a valid key.">>}}}
    ]}.
 
 valid_password(Password) when is_binary(Password) andalso byte_size(Password) >= 6 ->
@@ -60,18 +60,6 @@ valid_password(Password) when is_binary(Password) andalso byte_size(Password) >=
 valid_password(_Password) ->
   error.
 
-valid_public_key(PublicKey) ->
-    case chef_object:has_public_key_header(PublicKey) of
-        true ->
-            case chef_authn:extract_public_or_private_key(PublicKey) of
-                {error, bad_key} ->
-                    error;
-                _ ->
-                    ok
-            end;
-        false ->
-            error
-    end.
 
 
 assemble_user_ejson(#chef_user{username = Name,

--- a/src/chef_user.erl
+++ b/src/chef_user.erl
@@ -43,7 +43,8 @@ user_spec(create) ->
   {[
     {<<"name">>, {string_match, chef_regex:regex_for(user_name)}},
     {<<"password">>, {fun_match, {fun valid_password/1, string, <<"Password must have at least 6 characters">>}}},
-    {{opt,<<"admin">>}, boolean}
+    {{opt,<<"admin">>}, boolean},
+    {{opt,<<"public_key">>}, {fun_match, {fun valid_public_key/1, string, <<"Public Key must be a valid key.">>}}}
    ]};
 user_spec(update) ->
   {[

--- a/test/chef_user_tests.erl
+++ b/test/chef_user_tests.erl
@@ -1,0 +1,145 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92-*-
+%% ex: ts=4 sw=4 et
+%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+
+
+-module(chef_user_tests).
+
+-include_lib("chef_objects/include/chef_types.hrl").
+-include_lib("chef_objects/include/chef_osc_defaults.hrl").
+-include_lib("ej/include/ej.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+
+public_key_data() ->
+    {ok, Bin} = file:read_file("../test/spki_public.pem"),
+    Bin.
+
+cert_data() ->
+    {ok, Bin} = file:read_file("../test/cert.pem"),
+    Bin.
+
+assemble_user_ejson_test_() ->
+    [{"obtain expected EJSON",
+      fun() ->
+              User = #chef_user{username = <<"alice">>,
+                                admin = true,
+                                public_key = public_key_data()},
+              {GotList} = chef_user:assemble_user_ejson(User, ?OSC_ORG_NAME),
+              ExpectedData = [{<<"public_key">>, public_key_data()},
+                              {<<"admin">>, true},
+                              {<<"name">>, <<"alice">>}],
+              ?assertEqual(lists:sort(ExpectedData), lists:sort(GotList))
+      end}].
+
+parse_binary_json_test_() ->
+    [{"Can create with only name and password",
+      fun() ->
+              UserEjson = chef_json:encode({[
+                                             {<<"name">>, <<"bob">>},
+                                             {<<"password">>, <<"top secret 123456">>}
+                                            ]}),
+              {ok, User} = chef_user:parse_binary_json(UserEjson, create),
+              ExpectedData = [{<<"password">>, <<"top secret 123456">>},
+                              {<<"admin">>, false},
+                              {<<"name">>, <<"bob">>}],
+              {GotData} = User,
+              ?assertEqual(lists:sort(ExpectedData), lists:sort(GotData))
+      end
+     },
+
+     {"Password must be provided",
+      fun() ->
+              UserEjson = chef_json:encode({[{<<"name">>, <<"bob">>}]}),
+              ?assertThrow(#ej_invalid{}, chef_user:parse_binary_json(UserEjson, create))
+      end},
+
+     {"Password must be valid", generator,
+      fun() ->
+              BadPass = [<<"short">>, 123, [<<"longenoughbutinalist">>], {[]}, true, null],
+              Bodies = [ chef_json:encode({[{<<"name">>, <<"bob">>},
+                                            {<<"password">>, P}
+                                           ]})
+                         || P <- BadPass ],
+              [
+               ?_assertThrow(#ej_invalid{},
+                             chef_user:parse_binary_json(UserEjson, create))
+               || UserEjson <- Bodies ]
+      end},
+
+     {"Error thrown with bad name",
+      fun() ->
+              Body = <<"{\"name\":\"bad~name\"}">>,
+              ?assertThrow(#ej_invalid{},
+                           chef_user:parse_binary_json(Body, update))
+      end
+     },
+
+     {"a null public_key is removed for create",
+      fun() ->
+              Body = chef_json:encode({[
+                                        {<<"name">>, <<"user1">>},
+                                        {<<"password">>, <<"a password that is secret">>},
+                                        {<<"public_key">>, null}
+                                       ]}),
+              {ok, Got} = chef_user:parse_binary_json(Body, create),
+              ?assertEqual(undefined, ej:get({"public_key"}, Got))
+      end},
+
+     {"a null public_key is removed for update",
+      fun() ->
+              Body = chef_json:encode({[
+                                        {<<"name">>, <<"user1">>},
+                                        {<<"public_key">>, null}
+                                       ]}),
+              {ok, Got} = chef_user:parse_binary_json(Body, update),
+              ?assertEqual(undefined, ej:get({"public_key"}, Got))
+      end},
+
+     {"a valid public_key is preserved",
+      fun() ->
+              Body = chef_json:encode({[
+                                        {<<"name">>, <<"user1">>},
+                                        {<<"password">>, <<"a password that is secret">>},
+                                        {<<"public_key">>, public_key_data()}
+                                       ]}),
+              {ok, Got1} = chef_user:parse_binary_json(Body, create),
+              ?assertEqual(public_key_data(), ej:get({"public_key"}, Got1)),
+              {ok, Got2} = chef_user:parse_binary_json(Body, update),
+              ?assertEqual(public_key_data(), ej:get({"public_key"}, Got2))
+      end},
+
+     {"Errors thrown for invalid public_key data ", generator,
+      fun() ->
+              MungedKey = re:replace(public_key_data(), "A", "2",
+                                     [{return, binary}, global]),
+              BadKeys = [MungedKey,
+                         <<"a very bad key">>,
+                         true,
+                         113,
+                         [public_key_data()],
+                         {[]}],
+              Bodies = [ chef_json:encode({[
+                                            {<<"name">>, <<"client1">>},
+                                            {<<"public_key">>, Key}]})
+                         || Key <- BadKeys ],
+              [ ?_assertThrow(#ej_invalid{},
+                              chef_user:parse_binary_json(Body, update))
+                || Body <- Bodies ]
+      end}
+    ].


### PR DESCRIPTION
- Added a chef_object:valid_public_key/1
- Added the valid_public_key validator to users
- Added the valid_public_key validator to clients

Related:
- https://github.com/opscode/chef_wm/pull/42
- https://github.com/opscode/chef-pedant/pull/13
