### PR TITLE
 Fix for oc-6046; jiffy:encode can return iolists as well as binaries.

### DIFF
--- a/src/chef_json.erl
+++ b/src/chef_json.erl
@@ -38,7 +38,7 @@ decode(Bin) ->
     end.
 
 encode(EJSON) ->
-    jiffy:encode(EJSON).
+    erlang:iolist_to_binary(jiffy:encode(EJSON)).
 
 -spec decode_body( binary() ) -> ejson_term(). % or throw
 %% @doc Decodes JSON body and verifies valid payload type


### PR DESCRIPTION
For example the following hunk of ejson generates an iolist with jiffy.

```
{[{<<"silly_size">>,100000000000000000000}]}
```
