### PR TITLE
CHEF-3976: Remove validation for  "provides" attribute in cookbook metadata

### DIFF
--- a/src/chef_cookbook.erl
+++ b/src/chef_cookbook.erl
@@ -146,10 +146,9 @@ cookbook_spec(CBName, CBVersion) ->
                         {{opt, <<"suggestions">>}, constraint_map_spec(cookbook_name)},
                         {{opt, <<"conflicting">>}, constraint_map_spec(cookbook_name)},
                         {{opt, <<"replacing">>}, constraint_map_spec(cookbook_name)},
-                        {{opt, <<"providing">>}, constraint_map_spec(recipe_name)},
-                        %% FIXME: what's this? -
-                        {{opt, <<"groupings">>}, object}
-
+                        %% Accept anything for "providing"
+                         %% FIXME: what's this?
+                         {{opt, <<"groupings">>}, object}
                        ]}},
       {{opt, <<"attributes">>}, file_list_spec()},
       {{opt, <<"definitions">>}, file_list_spec()},


### PR DESCRIPTION
As per discussion in http://tickets.oscode.com/browse/CHEF-3976

We should be able to use the 'provides' examples from our published docs
(http://docs.opscode.com/config_rb_metadata.html) but the server will
reject these as invalid cookbook metadata.

The "provides" field in the cookbook metadata were not intended to be
machine readable. It is not used for anything on the server. However,
knife will reinforce some constraints. Using the example from the docs:

```
maintainer       "Chef's"
maintainer_email "chef@opscode.com"
license          "All rights reserved"
description      "Installs/Configures joy_of_cooking"
long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
version          "0.0.1"

provides "cats::sleep"
provides "cats::eat"
provides "here(:kitty, :time_to_eat)"
provides "service[snuggle]"
```

Knife will send up a JSON that has this for metadata.providing:

```
{
  ...
    "providing": {
      "joy_of_cooking": ">= 0.0.0",
      "cats::sleep": ">= 0.0.0",
      "cats::eat": ">= 0.0.0",
      "here(:kitty, :time_to_eat)": ">= 0.0.0",
      "service[snuggle]": ">= 0.0.0"
    }
}
```

It was decided to remove the validation completely. Eunit tests have
been updated to reflect this new reality.

Supercedes: https://github.com/opscode/chef_objects/pull/36
Requires: https://github.com/opscode/chef-pedant/pull/42
