### PR TITLE
if a dependency contains a recipe name trim it before adding while building depsolver constraints

### DIFF
--- a/src/chef_cookbook.erl
+++ b/src/chef_cookbook.erl
@@ -30,7 +30,8 @@
          constraint_map_spec/1,
          version_to_binary/1,
          parse_version/1,
-         qualified_recipe_names/2
+         qualified_recipe_names/2,
+         base_cookbook_name/1
         ]).
 
 -ifdef(TEST).
@@ -320,6 +321,23 @@ qualified_recipe_names(CookbookName, SerializedObject) ->
     Recipes = extract_recipe_names(SerializedObject),
     [ maybe_qualify_name(CookbookName, RecipeName)
       || RecipeName <- Recipes ].
+
+
+%% @doc for a given qualified recipe name, extract the base cookbook
+%% name. If the input is not a qualified recipe name, return it
+%% unmodified.
+-spec base_cookbook_name(binary()|string()) -> binary().
+base_cookbook_name(Recipe) when is_list(Recipe) ->
+    base_cookbook_name(list_to_binary(Recipe));
+base_cookbook_name(Recipe) when is_binary(Recipe) ->
+    case re:split(Recipe, <<"::">>) of
+        [Cookbook, _Recipe] ->
+            Cookbook;
+        [Cookbook] ->
+            Cookbook
+    end;
+base_cookbook_name(Recipe) ->
+    Recipe.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% Private Functions

--- a/src/chef_cookbook.erl
+++ b/src/chef_cookbook.erl
@@ -326,18 +326,14 @@ qualified_recipe_names(CookbookName, SerializedObject) ->
 %% @doc for a given qualified recipe name, extract the base cookbook
 %% name. If the input is not a qualified recipe name, return it
 %% unmodified.
--spec base_cookbook_name(binary()|string()) -> binary().
-base_cookbook_name(Recipe) when is_list(Recipe) ->
-    base_cookbook_name(list_to_binary(Recipe));
-base_cookbook_name(Recipe) when is_binary(Recipe) ->
-    case re:split(Recipe, <<"::">>) of
+-spec base_cookbook_name(binary() | string()) -> binary().
+base_cookbook_name(Recipe) ->
+    case re:split(Recipe, <<"::">>, [{return, binary}]) of
         [Cookbook, _Recipe] ->
             Cookbook;
         [Cookbook] ->
             Cookbook
-    end;
-base_cookbook_name(Recipe) ->
-    Recipe.
+    end.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% Private Functions

--- a/src/chef_object.erl
+++ b/src/chef_object.erl
@@ -497,10 +497,10 @@ depsolver_constraints({Constraints}) when is_list(Constraints) ->
 %% @doc Convert a cookbook name / version constraint string pair into a valid depsolver
 %% constraint.  Mainly ensures the types of the various components are correct, as depsolver
 %% works mainly with strings and atoms, instead of binaries.
--spec process_constraint_for_depsolver({_, binary()}) -> {_, binary(), '<' | '<=' | '=' | '>' | '>=' | '~>'}.
+-spec process_constraint_for_depsolver({binary(), binary()}) -> {binary(), binary(), '<' | '<=' | '=' | '>' | '>=' | '~>'}.
 process_constraint_for_depsolver({Name, ConstraintString}) ->
     {Comparator, Version} = parse_constraint(ConstraintString),
-    {Name, Version, Comparator}.
+    {chef_cookbook:base_cookbook_name(Name), Version, Comparator}.
 
 %% @doc Given a version constraint string (e.g., `<<">= 1.5.0">>'), extract the comparison
 %% operator and version and present them as a paired tuple.

--- a/test/chef_cookbook_tests.erl
+++ b/test/chef_cookbook_tests.erl
@@ -377,7 +377,8 @@ base_cookbook_name_test_() ->
              %% {Input, Expected}
              {<<"apache2::default">>, <<"apache2">>},
              {"apache2::default",     <<"apache2">>},
-             {<<"apache2">>,          <<"apache2">>}
+             {<<"apache2">>,          <<"apache2">>},
+             {"apache2",              <<"apache2">>}
             ],
     [ ?_assertEqual(Expected, chef_cookbook:base_cookbook_name(Input))
       || {Input, Expected} <- Tests ].

--- a/test/chef_cookbook_tests.erl
+++ b/test/chef_cookbook_tests.erl
@@ -371,3 +371,13 @@ maybe_qualify_name_test_() ->
       ?_assertEqual(<<"cookbook::default.rb">>,
                     chef_cookbook:maybe_qualify_name(<<"cookbook">>, <<"default.rb.rb">>))}
     ].
+
+base_cookbook_name_test_() ->
+    Tests = [
+             %% {Input, Expected}
+             {<<"apache2::default">>, <<"apache2">>},
+             {"apache2::default",     <<"apache2">>},
+             {<<"apache2">>,          <<"apache2">>}
+            ],
+    [ ?_assertEqual(Expected, chef_cookbook:base_cookbook_name(Input))
+      || {Input, Expected} <- Tests ].


### PR DESCRIPTION
Ensures compatibility with ruby code, which strips recipe name before passing the graph along to depselector.
