### PR TITLE
Ruby Depsolver: Catch exceptions and return detail to Erlang

### DIFF
--- a/priv/depselector_rb/depselector.rb
+++ b/priv/depselector_rb/depselector.rb
@@ -32,96 +32,101 @@ end
 
 receive do |m|
   m.when([:solve, Erl.hash]) do |data|
-    # create dependency graph from cookbooks
-    graph = DepSelector::DependencyGraph.new
+    begin
+      # create dependency graph from cookbooks
+      graph = DepSelector::DependencyGraph.new
 
-    env_constraints = data[:environment_constraints].inject({}) do |acc, env_constraint|
-      name, version, constraint = env_constraint
-      acc[name] = DepSelector::VersionConstraint.new(constraint_to_str(constraint, version))
-      acc
-    end
-
-    all_versions = []
-
-    data[:all_versions].each do | vsn|
-      name, version_constraints = vsn
-      version_constraints.each do |version_constraint| # todo: constraints become an array in ruby
-                                                       # due to the erlectricity conversion from
-                                                       # tuples
-        version, constraints = version_constraint
-
-        # filter versions based on environment constraints
-        env_constraint = env_constraints[name]
-        if (!env_constraint || env_constraint.include?(DepSelector::Version.new(version)))
-          package_version = graph.package(name).add_version(DepSelector::Version.new(version))
-          constraints.each do |package_constraint|
-            constraint_name, constraint_version, constraint = package_constraint
-            version_constraint = DepSelector::VersionConstraint.new(constraint_to_str(constraint, constraint_version))
-            dependency = DepSelector::Dependency.new(graph.package(constraint_name), version_constraint)
-            package_version.dependencies << dependency
-          end
-        end
+      env_constraints = data[:environment_constraints].inject({}) do |acc, env_constraint|
+        name, version, constraint = env_constraint
+        acc[name] = DepSelector::VersionConstraint.new(constraint_to_str(constraint, version))
+        acc
       end
 
-      # regardless of filter, add package reference to all_packages
-      all_versions << graph.package(name)
+      all_versions = []
+
+      data[:all_versions].each do | vsn|
+        name, version_constraints = vsn
+        version_constraints.each do |version_constraint| # todo: constraints become an array in ruby
+                                                         # due to the erlectricity conversion from
+                                                         # tuples
+          version, constraints = version_constraint
+
+          # filter versions based on environment constraints
+          env_constraint = env_constraints[name]
+          if (!env_constraint || env_constraint.include?(DepSelector::Version.new(version)))
+            package_version = graph.package(name).add_version(DepSelector::Version.new(version))
+            constraints.each do |package_constraint|
+              constraint_name, constraint_version, constraint = package_constraint
+              version_constraint = DepSelector::VersionConstraint.new(constraint_to_str(constraint, constraint_version))
+              dependency = DepSelector::Dependency.new(graph.package(constraint_name), version_constraint)
+              package_version.dependencies << dependency
+            end
+          end
+        end
+
+        # regardless of filter, add package reference to all_packages
+        all_versions << graph.package(name)
+      end
+
+      run_list = data[:run_list].map do |run_list_item|
+        item_name, item_constraint_version, item_constraint = run_list_item
+        version_constraint = DepSelector::VersionConstraint.new(constraint_to_str(item_constraint,
+                                                                                  item_constraint_version))
+        DepSelector::SolutionConstraint.new(graph.package(item_name), version_constraint)
+      end
+
+      timeout_ms = data[:timeout_ms]
+      selector = DepSelector::Selector.new(graph, (timeout_ms / 1000.0))
+
+      answer = begin
+                 solution = selector.find_solution(run_list, all_versions)
+                 packages = Erl::List.new
+                 solution.each do |package, v|
+                   packages << [package, [v.major, v.minor, v.patch]]
+                 end
+                 [:ok, packages]
+               rescue DepSelector::Exceptions::InvalidSolutionConstraints => e
+                 non_existent_cookbooks = e.non_existent_packages.inject(Erl::List.new) do |list, constraint|
+                   list << constraint.package.name
+                 end
+
+                 constrained_to_no_versions = e.constrained_to_no_versions.inject(Erl::List.new) do |list, constraint|
+                   list << constraint.to_s
+                 end
+
+                 error_detail = Erl::List.new([[:non_existent_cookbooks, non_existent_cookbooks],
+                                               [:constraints_not_met, constrained_to_no_versions]])
+
+                 [:error, :invalid_constraints, error_detail]
+               rescue DepSelector::Exceptions::NoSolutionExists => e
+                 most_constrained_cookbooks = e.disabled_most_constrained_packages.inject(Erl::List.new) do |list, package|
+                   # WTF: this is the reported error format but I can't find this anywhere in the ruby code
+                   list << "#{package.name} = #{package.versions.first.to_s}"
+                 end
+
+                 non_existent_cookbooks = e.disabled_non_existent_packages.inject(Erl::List.new) do |list, package|
+                   list << package.name
+                 end
+
+                 error_detail = Erl::List.new([[:message, e.message],
+                                               [:unsatisfiable_run_list_item, e.unsatisfiable_solution_constraint.to_s],
+                                               [:non_existent_cookbooks, non_existent_cookbooks],
+                                               [:most_constrained_cookbooks, most_constrained_cookbooks]])
+
+                 [:error, :no_solution, error_detail]
+               rescue DepSelector::Exceptions::TimeBoundExceeded,
+                      DepSelector::Exceptions::TimeBoundExceededNoSolution => e
+                 # While dep_selector differentiates between the two solutions, the opscode-chef
+                 # API returns the same error regardless of the timeout type. We'll swallow the
+                 # difference here and return a unified timeout to erchef
+                 [:error, :resolution_timeout]
+               end
+      m.send!(answer)
+      m.receive_loop
+    rescue => e
+      answer = [:error, :exception, e.message, Erl::List.new(e.backtrace)]
+      m.send!(answer)
+      m.receive_loop
     end
-
-    run_list = data[:run_list].map do |run_list_item|
-      item_name, item_constraint_version, item_constraint = run_list_item
-      version_constraint = DepSelector::VersionConstraint.new(constraint_to_str(item_constraint,
-                                                                                item_constraint_version))
-      DepSelector::SolutionConstraint.new(graph.package(item_name), version_constraint)
-    end
-
-    timeout_ms = data[:timeout_ms]
-    selector = DepSelector::Selector.new(graph, (timeout_ms / 1000.0))
-
-    answer = begin
-               solution = selector.find_solution(run_list, all_versions)
-               packages = Erl::List.new
-               solution.each do |package, v|
-                 packages << [package, [v.major, v.minor, v.patch]]
-               end
-               [:ok, packages]
-             rescue DepSelector::Exceptions::InvalidSolutionConstraints => e
-               non_existent_cookbooks = e.non_existent_packages.inject(Erl::List.new) do |list, constraint|
-                 list << constraint.package.name
-               end
-
-               constrained_to_no_versions = e.constrained_to_no_versions.inject(Erl::List.new) do |list, constraint|
-                 list << constraint.to_s
-               end
-
-               error_detail = Erl::List.new([[:non_existent_cookbooks, non_existent_cookbooks],
-                                             [:constraints_not_met, constrained_to_no_versions]])
-
-               [:error, :invalid_constraints, error_detail]
-             rescue DepSelector::Exceptions::NoSolutionExists => e
-               most_constrained_cookbooks = e.disabled_most_constrained_packages.inject(Erl::List.new) do |list, package|
-                 # WTF: this is the reported error format but I can't find this anywhere in the ruby code
-                 list << "#{package.name} = #{package.versions.first.to_s}"
-               end
-
-               non_existent_cookbooks = e.disabled_non_existent_packages.inject(Erl::List.new) do |list, package|
-                 list << package.name
-               end
-
-               error_detail = Erl::List.new([[:message, e.message],
-                                             [:unsatisfiable_run_list_item, e.unsatisfiable_solution_constraint.to_s],
-                                             [:non_existent_cookbooks, non_existent_cookbooks],
-                                             [:most_constrained_cookbooks, most_constrained_cookbooks]])
-
-               [:error, :no_solution, error_detail]
-             rescue DepSelector::Exceptions::TimeBoundExceeded,
-                    DepSelector::Exceptions::TimeBoundExceededNoSolution => e
-               # While dep_selector differentiates between the two solutions, the opscode-chef
-               # API returns the same error regardless of the timeout type. We'll swallow the
-               # difference here and return a unified timeout to erchef
-               [:error, :resolution_timeout]
-             end
-
-    m.send!(answer)
-    m.receive_loop
   end
 end

--- a/src/chef_depsolver_worker.erl
+++ b/src/chef_depsolver_worker.erl
@@ -104,7 +104,11 @@ solve_dependencies(AllVersions, EnvConstraints, Cookbooks, Timeout) ->
 %%--------------------------------------------------------------------
 init([]) ->
     RubyExecutable = filename:join([code:priv_dir(chef_objects), "depselector_rb", "depselector.rb"]),
-    Port = open_port({spawn, "ruby " ++ RubyExecutable},
+    %% - redirect stderr to /dev/null -
+    %% The C-level implementation of the ruby depsolver prints out statistics to stderr.
+    %% These show up in the erchef console log, and the data we care about here is
+    %% already captured in stats_hero and logs.
+    Port = open_port({spawn, "ruby " ++ RubyExecutable ++ " 2> /dev/null"},
                      [{packet, 4}, nouse_stdio, exit_status, binary]),
     {ok, #state{port=Port}}.
 

--- a/test/chef_depsolver_tests.erl
+++ b/test/chef_depsolver_tests.erl
@@ -64,7 +64,8 @@ all_test_() ->
     {?MODULE, depsolver_missing},
     {?MODULE, depsolver_missing_via_culprit_search},
     {?MODULE, depsolver_binary},
-    {?MODULE, depsolver_no_workers}
+    {?MODULE, depsolver_no_workers},
+    {?MODULE, depsolver_negative_version}
    ]
   }.
 
@@ -614,6 +615,12 @@ depsolver_no_workers() ->
     RunList = [<<"app1">>],
     _Steal = pooler:take_member(chef_depsolver),
     ?assertEqual({error, no_depsolver_workers},
+                 chef_depsolver:solve_dependencies(World, [], RunList)).
+
+depsolver_negative_version() ->
+    World = [{<<"app1">>, [{<<"1.1.-42">>}], []}],
+    RunList = [<<"app1">>],
+    ?assertMatch({error, exception, _Message, _Backtrace},
                  chef_depsolver:solve_dependencies(World, [], RunList)).
 
 make_env(Name, Deps) ->


### PR DESCRIPTION
### Motivation

The currently-deployed ruby depsolver code does not handle or deal with exceptions outside of the ones thrown by dep_selector during solving. Any exceptions returned will cause the worker to crash. When the worker crashes, the erlang process is left waiting for a reply for up to 10 seconds. We also get a spew of ruby backtrace in the erlang console log that isn't tightly coupled to any single response.
### Solution

Wrap the entire receive loop in a begin/rescue clause and return exception detail to Erlang. This will let the process return quickly, stay alive, and allow erlang to properly format the error message in the logs.
