### PR TITLE
[ruby-depsolver] depsolver feature in ruby

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@ DEPS = $(CURDIR)/deps
 DIALYZER_OPTS = -Wunderspecs
 
 DIALYZER_DEPS = deps/chef_authn/ebin \
-                deps/depsolver/ebin \
                 deps/ej/ebin \
                 deps/jiffy/ebin \
                 deps/ibrowse/ebin \
@@ -53,13 +52,16 @@ compile: $(DEPS)
 $(DEPS):
 	@rebar get-deps
 
+bundle:
+	@cd priv/depselector_rb; bundle install
+
 # Full clean and removal of all deps. Remove deps first to avoid
 # wasted effort of cleaning deps before nuking them.
 distclean:
-	@rm -rf deps $(DEPS_PLT)
+	@rm -rf deps $(DEPS_PLT) priv/depselector_rb/.bundle
 	@rebar clean
 
-eunit:
+eunit: compile bundle
 	@rebar skip_deps=true eunit
 
 test: eunit

--- a/priv/depselector_rb/Gemfile
+++ b/priv/depselector_rb/Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'dep_selector', :git => 'git://github.com/opscode/dep-selector', :branch => 'master'
+gem 'erlectricity', :git => 'git://github.com/sdelano/erlectricity', :branch => 'master'
+gem 'uuidtools'

--- a/priv/depselector_rb/Gemfile.lock
+++ b/priv/depselector_rb/Gemfile.lock
@@ -1,0 +1,26 @@
+GIT
+  remote: git://github.com/opscode/dep-selector
+  revision: 9f97b663e923700070e8fb08f6b94629147a152d
+  branch: master
+  specs:
+    dep_selector (0.1.0)
+
+GIT
+  remote: git://github.com/sdelano/erlectricity
+  revision: b8b627fbc4b82cbfe2807ab62733ba0a65d0c209
+  branch: master
+  specs:
+    erlectricity (1.1.1)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    uuidtools (2.1.4)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  dep_selector!
+  erlectricity!
+  uuidtools

--- a/priv/depselector_rb/depselector.rb
+++ b/priv/depselector_rb/depselector.rb
@@ -1,0 +1,127 @@
+# ensure that the Gemfile is in the cwd
+Dir.chdir(File.dirname(__FILE__))
+
+require 'rubygems'
+require 'bundler/setup'
+require 'dep_selector'
+require 'erlectricity'
+
+def translate_constraint(constraint)
+  case constraint
+  when Symbol
+    case constraint
+    when :gt then ">"
+    when :gte then ">="
+    when :lt then "<"
+    when :lte then "<="
+    when :eq then "="
+    when :pes then "~>"
+    else constraint.to_s
+    end
+  when NilClass
+    "="
+  else
+    constraint
+  end
+end
+
+def constraint_to_str(constraint, constraint_version)
+  return nil unless constraint_version
+  "#{translate_constraint(constraint)} #{constraint_version}"
+end
+
+receive do |m|
+  m.when([:solve, Erl.hash]) do |data|
+    # create dependency graph from cookbooks
+    graph = DepSelector::DependencyGraph.new
+
+    env_constraints = data[:environment_constraints].inject({}) do |acc, env_constraint|
+      name, version, constraint = env_constraint
+      acc[name] = DepSelector::VersionConstraint.new(constraint_to_str(constraint, version))
+      acc
+    end
+
+    all_versions = []
+
+    data[:all_versions].each do | vsn|
+      name, version_constraints = vsn
+      version_constraints.each do |version_constraint| # todo: constraints become an array in ruby
+                                                       # due to the erlectricity conversion from
+                                                       # tuples
+        version, constraints = version_constraint
+
+        # filter versions based on environment constraints
+        env_constraint = env_constraints[name]
+        if (!env_constraint || env_constraint.include?(DepSelector::Version.new(version)))
+          package_version = graph.package(name).add_version(DepSelector::Version.new(version))
+          constraints.each do |package_constraint|
+            constraint_name, constraint_version, constraint = package_constraint
+            version_constraint = DepSelector::VersionConstraint.new(constraint_to_str(constraint, constraint_version))
+            dependency = DepSelector::Dependency.new(graph.package(constraint_name), version_constraint)
+            package_version.dependencies << dependency
+          end
+        end
+      end
+
+      # regardless of filter, add package reference to all_packages
+      all_versions << graph.package(name)
+    end
+
+    run_list = data[:run_list].map do |run_list_item|
+      item_name, item_constraint_version, item_constraint = run_list_item
+      version_constraint = DepSelector::VersionConstraint.new(constraint_to_str(item_constraint,
+                                                                                item_constraint_version))
+      DepSelector::SolutionConstraint.new(graph.package(item_name), version_constraint)
+    end
+
+    timeout_ms = data[:timeout_ms]
+    selector = DepSelector::Selector.new(graph, (timeout_ms / 1000.0))
+
+    answer = begin
+               solution = selector.find_solution(run_list, all_versions)
+               packages = Erl::List.new
+               solution.each do |package, v|
+                 packages << [package, [v.major, v.minor, v.patch]]
+               end
+               [:ok, packages]
+             rescue DepSelector::Exceptions::InvalidSolutionConstraints => e
+               non_existent_cookbooks = e.non_existent_packages.inject(Erl::List.new) do |list, constraint|
+                 list << constraint.package.name
+               end
+
+               constrained_to_no_versions = e.constrained_to_no_versions.inject(Erl::List.new) do |list, constraint|
+                 list << constraint.to_s
+               end
+
+               error_detail = Erl::List.new([[:non_existent_cookbooks, non_existent_cookbooks],
+                                             [:constraints_not_met, constrained_to_no_versions]])
+
+               [:error, :invalid_constraints, error_detail]
+             rescue DepSelector::Exceptions::NoSolutionExists => e
+               most_constrained_cookbooks = e.disabled_most_constrained_packages.inject(Erl::List.new) do |list, package|
+                 # WTF: this is the reported error format but I can't find this anywhere in the ruby code
+                 list << "#{package.name} = #{package.versions.first.to_s}"
+               end
+
+               non_existent_cookbooks = e.disabled_non_existent_packages.inject(Erl::List.new) do |list, package|
+                 list << package.name
+               end
+
+               error_detail = Erl::List.new([[:message, e.message],
+                                             [:unsatisfiable_run_list_item, e.unsatisfiable_solution_constraint.to_s],
+                                             [:non_existent_cookbooks, non_existent_cookbooks],
+                                             [:most_constrained_cookbooks, most_constrained_cookbooks]])
+
+               [:error, :no_solution, error_detail]
+             rescue DepSelector::Exceptions::TimeBoundExceeded,
+                    DepSelector::Exceptions::TimeBoundExceededNoSolution => e
+               # While dep_selector differentiates between the two solutions, the opscode-chef
+               # API returns the same error regardless of the timeout type. We'll swallow the
+               # difference here and return a unified timeout to erchef
+               [:error, :resolution_timeout]
+             end
+
+    m.send!(answer)
+    m.receive_loop
+  end
+end

--- a/rebar.config
+++ b/rebar.config
@@ -14,12 +14,12 @@
          {git, "git://github.com/opscode/ibrowse.git", {tag, "v4.0.1.1"}}},
         {mini_s3, ".*",
          {git, "git://github.com/opscode/mini_s3.git", {branch, "master"}}},
-        {depsolver, ".*",
-         {git, "git://github.com/opscode/depsolver.git", {branch, "master"}}},
         {chef_authn, ".*",
          {git, "git://github.com/opscode/chef_authn.git", {branch, "master"}}},
         {opscoderl_folsom, ".*",
-         {git, "git://github.com/opscode/opscoderl_folsom.git", {branch, "master"}}}
+         {git, "git://github.com/opscode/opscoderl_folsom.git", {branch, "master"}}},
+        {pooler, ".*",
+         {git, "git://github.com/seth/pooler.git", {tag, "1.0.0"}}}
        ]}.
 
 {cover_enabled, true}.

--- a/src/chef_depsolver_worker.erl
+++ b/src/chef_depsolver_worker.erl
@@ -1,0 +1,203 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
+%% ex: ts=4 sw=4 et
+%%%-------------------------------------------------------------------
+%%% @author Stephen Delano <stephen@opscode.com>
+%%% @doc Worker module for chef_depsolver resource
+%%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%%%
+%%% This file is provided to you under the Apache License,
+%%% Version 2.0 (the "License"); you may not use this file
+%%% except in compliance with the License.  You may obtain
+%%% a copy of the License at
+%%%
+%%%   http://www.apache.org/licenses/LICENSE-2.0
+%%%
+%%% Unless required by applicable law or agreed to in writing,
+%%% software distributed under the License is distributed on an
+%%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%%% KIND, either express or implied.  See the License for the
+%%% specific language governing permissions and limitations
+%%% under the License.
+%%%
+%%% Created : 31 Jul 2013 by Stephen Delano <stephen@opscode.com>
+%%%-------------------------------------------------------------------
+-module(chef_depsolver_worker).
+
+-behaviour(gen_server).
+
+%% API
+-export([solve_dependencies/4,
+         start_link/0]).
+
+%% gen_server callbacks
+-export([code_change/3,
+         handle_call/3,
+         handle_cast/2,
+         handle_info/2,
+         init/1,
+         terminate/2]).
+
+
+-define(SERVER, chef_depsolver).
+
+-record(state, {port}).
+
+-include_lib("eunit/include/eunit.hrl"). %% TODO: remove
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Starts the server
+%%
+%% @spec start_link() -> {ok, Pid} | ignore | {error, Error}
+%% @end
+%%--------------------------------------------------------------------
+start_link() ->
+    gen_server:start_link(?MODULE, [], []).
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Solve dependencies with the given state and constraints
+%% @end
+%%--------------------------------------------------------------------
+-spec solve_dependencies(AllVersions :: [chef_depsolver:dependency_set()],
+                         EnvConstraints :: [chef_depsolver:constraint()],
+                         Cookbooks :: [Name::binary() |
+                                             {Name::binary(), Version::binary()}],
+                         Timeout :: integer()) ->
+                                {ok, [ chef_depsolver:versioned_cookbook()]} | {error, term()}.
+solve_dependencies(AllVersions, EnvConstraints, Cookbooks, Timeout) ->
+    case pooler:take_member(chef_depsolver) of
+        error_no_members ->
+            {error, no_depsolver_workers};
+        Pid ->
+            case gen_server:call(Pid, {solve, AllVersions, EnvConstraints, Cookbooks, Timeout}, infinity) of
+                {error, resolution_timeout} ->
+                    %% testing has shown that returning the worker to the pool
+                    %% with 'fail' will reliably stop the ruby sub-process
+                    %% and not leave zombie processes consuming system resources.
+                    pooler:return_member(chef_depsolver, Pid, fail),
+                    {error, resolution_timeout};
+                Result ->
+                    pooler:return_member(chef_depsolver, Pid, ok),
+                    Result
+            end
+    end.
+
+%%%===================================================================
+%%% gen_server callbacks
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Initializes the server
+%%
+%% @spec init(Args) -> {ok, State} |
+%%                     {ok, State, Timeout} |
+%%                     ignore |
+%%                     {stop, Reason}
+%% @end
+%%--------------------------------------------------------------------
+init([]) ->
+    RubyExecutable = filename:join([code:priv_dir(chef_objects), "depselector_rb", "depselector.rb"]),
+    Port = open_port({spawn, "ruby " ++ RubyExecutable},
+                     [{packet, 4}, nouse_stdio, exit_status, binary]),
+    {ok, #state{port=Port}}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Handling call messages
+%%
+%% @spec handle_call(Request, From, State) ->
+%%                                   {reply, Reply, State} |
+%%                                   {reply, Reply, State, Timeout} |
+%%                                   {noreply, State} |
+%%                                   {noreply, State, Timeout} |
+%%                                   {stop, Reason, Reply, State} |
+%%                                   {stop, Reason, State}
+%% @end
+%%--------------------------------------------------------------------
+handle_call({solve, AllVersions, EnvConstraints, Cookbooks, Timeout}, _From, #state{port=Port} = State) ->
+    Payload = term_to_binary({solve, [{environment_constraints, EnvConstraints},
+                                      {all_versions, AllVersions},
+                                      {run_list, Cookbooks},
+                                      {timeout_ms, Timeout}]}),
+    port_command(Port, Payload),
+
+    %% The underlying ruby code has the potential to reach nearly 2x the
+    %% timeout value passed in. The timeout value is applied first on the
+    %% initial solve. If a solution fails within the timeout, the timeout
+    %% is then applied again to the culprit search. To account for this
+    %% worst case scenario, we will double the receive timeout and add a
+    %% small buffer of 50ms to account for inter-process communication
+    %% time.
+    ReceiveTimeout = (Timeout * 2) + 50,
+
+    Reply = receive
+                {Port, {data, Data}} ->
+                    binary_to_term(Data)
+            after
+                ReceiveTimeout ->
+                    {error, resolution_timeout}
+            end,
+    {reply, Reply, State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Handling cast messages
+%%
+%% @spec handle_cast(Msg, State) -> {noreply, State} |
+%%                                  {noreply, State, Timeout} |
+%%                                  {stop, Reason, State}
+%% @end
+%%--------------------------------------------------------------------
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Handling all non call/cast messages
+%%
+%% @spec handle_info(Info, State) -> {noreply, State} |
+%%                                   {noreply, State, Timeout} |
+%%                                   {stop, Reason, State}
+%% @end
+%%--------------------------------------------------------------------
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% This function is called by a gen_server when it is about to
+%% terminate. It should be the opposite of Module:init/1 and do any
+%% necessary cleaning up. When it returns, the gen_server terminates
+%% with Reason. The return value is ignored.
+%%
+%% @spec terminate(Reason, State) -> void()
+%% @end
+%%--------------------------------------------------------------------
+terminate(_Reason, _State) ->
+    ok.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Convert process state when code is changed
+%%
+%% @spec code_change(OldVsn, State, Extra) -> {ok, NewState}
+%% @end
+%%--------------------------------------------------------------------
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================

--- a/src/chef_object.erl
+++ b/src/chef_object.erl
@@ -481,7 +481,7 @@ sql_date({_,_,_} = TS) ->
 -spec depsolver_constraints(#chef_environment{}
                             | binary()   % JSON string
                             | {[{Name::binary(), ConstraintString::binary()}]}) %% EJson hash
-                           -> [ depsolver:constraint() ].
+                           -> [ chef_depsolver:constraint() ].
 depsolver_constraints(#chef_environment{serialized_object=SerializedObject}) ->
     EJson = chef_db_compression:decompress_and_decode(SerializedObject),
     %% The "cookbook_versions" key is required for Environments, and will always be present

--- a/src/chef_objects.app.src
+++ b/src/chef_objects.app.src
@@ -23,9 +23,9 @@
   {applications, [
                   kernel,
                   stdlib,
-                  ejson,
                   ibrowse,
-                  depsolver
+                  folsom,
+                  pooler
                  ]},
   {env, []}
  ]}.


### PR DESCRIPTION
This feature implements the depsolver feature of the chef server in ruby
and interfaces with erlang over port drivers. The ruby processes are
managed with the pooler library.

/cc @seth 
