### PR TITLE
Convert to envy

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -21,7 +21,9 @@
         {pooler, ".*",
          {git, "git://github.com/seth/pooler.git", {tag, "1.0.0"}}},
         {mixer, ".*",
-         {git, "git://github.com/opscode/mixer.git", {tag, "0.1.1"}}}
+         {git, "git://github.com/opscode/mixer.git", {tag, "0.1.1"}}},
+        {envy, ".*",
+         {git, "git://github.com/manderson26/envy.git", {branch, "master"}}}
        ]}.
 
 {cover_enabled, true}.

--- a/src/chef_cert_http.erl
+++ b/src/chef_cert_http.erl
@@ -40,7 +40,8 @@ gen_cert(Guid, RequestId) ->
     FullHeaders = [{?X_OPS_REQUEST_ID, binary_to_list(RequestId)},
                    {"Accept", "application/json"}
                   ],
-    {ok, Url} = application:get_env(chef_objects, certificate_root_url),
+    
+    Url = envy:get(chef_objects, certificate_root_url, string),
     Body = body_for_post(Guid),
     case ibrowse:send_req(Url, FullHeaders, post, Body) of
         {ok, Code, ResponseHeaders, ResponseBody} ->

--- a/src/chef_config.erl
+++ b/src/chef_config.erl
@@ -28,32 +28,9 @@
 -type option_type() :: pos_integer.
 -type value_type() :: pos_integer().
 
-%% @doc Fetch a configuration value via `application:get_env/2` and
-%% verify it is of the given type.  Valid values are returned; invalid
-%% values trigger an error @end
 -spec config_option(Application :: atom(),
 		    OptionName :: atom(),
 		    Type :: option_type()) ->
 			   Value :: value_type().
 config_option(Application, OptionName, Type) ->
-    case application:get_env(Application, OptionName) of
-        {ok, Value} ->
-            case validate(Value, Type) of
-		true ->
-		    Value;
-		false ->
-		    error_logger:error_msg("Improper Configuration: ~p / ~p was ~p; should be a ~p~n",
-					   [Application, OptionName, Value, Type]),
-		    erlang:error({configuration, Application, OptionName, Value, Type})
-	    end;
-        undefined ->
-            error_logger:error_msg("Improper Configuration: ~p / ~p was undefined!~n",
-                                   [Application, OptionName]),
-            erlang:error({configuration, Application, OptionName, undefined})
-    end.
-
-%% @doc Return `true' if `Value' is of the specified `Type'; `false'
-%% otherwise.
--spec validate(Value :: term(), Type :: option_type()) -> boolean().
-validate(Value, pos_integer) when is_integer(Value) -> Value > 0;
-validate(_Value, pos_integer) -> false.
+    envy:get(Application, OptionName, Type).

--- a/src/chef_cookbook_version.erl
+++ b/src/chef_cookbook_version.erl
@@ -537,10 +537,7 @@ extract_recipe_names(<<31, 139, _Rest/binary>>=XCookbookJSON) ->
 %% @doc Return the s3_url_ttl from the application environment, if it is
 %% undefined return the default value set in ?DEFAULT_S3_URL_TTL
 url_ttl() ->
-    case application:get_env(chef_objects, s3_url_ttl) of
-        {ok, S3TTL} -> S3TTL;
-        undefined          -> ?DEFAULT_S3_URL_TTL
-    end.
+    envy:get(chef_objects, s3_url_ttl, ?DEFAULT_S3_URL_TTL, pos_integer).
 
 %% @doc Given a list of files for a particular segment add in a S3 URL per file
 %% based on the checksum

--- a/src/chef_depsolver.erl
+++ b/src/chef_depsolver.erl
@@ -124,14 +124,7 @@ solve_dependencies(AllVersions, EnvConstraints, Cookbooks) ->
                                              depsolver_timeout()).
 
 depsolver_timeout() ->
-    case application:get_env(chef_objects, depsolver_timeout) of
-        undefined ->
-            ?DEFAULT_DEPSOLVER_TIMEOUT;
-        {ok, Value} when is_integer(Value) ->
-            Value;
-        Bad ->
-            error({invalid_config, {chef_objects, depsolver_timeout, Bad}})
-    end.
+    envy:get(chef_objects, depsolver_timeout, ?DEFAULT_DEPSOLVER_TIMEOUT, non_neg_integer).
 
 folsom_time(M, F, Fun) ->
     Label = oc_folsom:mf_label(M, F),

--- a/src/chef_metrics.erl
+++ b/src/chef_metrics.erl
@@ -50,8 +50,8 @@ label(s3=Upstream, {Mod, Fun}) when is_atom(Mod),
     %% using different S3 regions on latency and performance.
     %%
     %% Because data.
-    {ok, Url} = application:get_env(chef_objects, s3_url),
-    {ok, Bucket} = application:get_env(chef_objects, s3_platform_bucket_name),
+    Url = envy:get(chef_objects, s3_url, string),
+    Bucket = envy:get(chef_objects, s3_platform_bucket_name, string),
 
     %% These two components need to have '.' characters stripped so
     %% that we don't inadvertently introduce new hierarchy levels into

--- a/test/chef_config_tests.erl
+++ b/test/chef_config_tests.erl
@@ -47,13 +47,13 @@ config_option_test_() ->
 		fun() ->
 			case {Value, ErrorState} of
 			    {undefined, _} ->
-				?assertError({configuration, TestApplication, TestOption, undefined},
+				?assertError(config_missing_item,
 					     chef_config:config_option(TestApplication, TestOption, Type));
 			    {_, no_error} ->
 				?assertEqual(Value,
 					     chef_config:config_option(TestApplication, TestOption, Type));
 			    {_, error} ->
-				?assertError({configuration, TestApplication, TestOption, Value, Type},
+				?assertError(config_bad_type,
 					     chef_config:config_option(TestApplication, TestOption, Type))
 			end
 		end}


### PR DESCRIPTION
Application:get_env requires validation of data types.  This logic has been 
duplicated several times.  This attempts to consolidate validation to a single
library, envy.
