### PR TITLE
Continue to consolidate chef_object api to now include update

### DIFF
--- a/src/chef_client.erl
+++ b/src/chef_client.erl
@@ -58,7 +58,10 @@
         ]).
 
 -include_lib("mixer/include/mixer.hrl").
--mixin([{chef_object,[{default_fetch/2, fetch}]}]).
+-mixin([{chef_object,[
+                      {default_fetch/2, fetch},
+                      {default_update/2, update}
+                     ]}]).
 
 -export([
          list/2

--- a/src/chef_cookbook_version.erl
+++ b/src/chef_cookbook_version.erl
@@ -60,8 +60,10 @@
         ]).
 
 -include_lib("mixer/include/mixer.hrl").
--mixin([{chef_object,[{default_fetch/2, fetch}]}]).
-
+-mixin([{chef_object,[
+                      {default_fetch/2, fetch},
+                      {default_update/2, update}
+                     ]}]).
 -export([
          list/2
          ]).

--- a/src/chef_data_bag.erl
+++ b/src/chef_data_bag.erl
@@ -50,8 +50,10 @@
         ]).
 
 -include_lib("mixer/include/mixer.hrl").
--mixin([{chef_object,[{default_fetch/2, fetch}]}]).
-
+-mixin([{chef_object,[
+                      {default_fetch/2, fetch},
+                      {default_update/2, update}
+                     ]}]).
 -export([
          list/2
          ]).

--- a/src/chef_data_bag_item.erl
+++ b/src/chef_data_bag_item.erl
@@ -53,8 +53,10 @@
         ]).
 
 -include_lib("mixer/include/mixer.hrl").
--mixin([{chef_object,[{default_fetch/2, fetch}]}]).
-
+-mixin([{chef_object,[
+                      {default_fetch/2, fetch},
+                      {default_update/2, update}
+                     ]}]).
 -export([
          list/2
          ]).

--- a/src/chef_environment.erl
+++ b/src/chef_environment.erl
@@ -52,8 +52,10 @@
         ]).
 
 -include_lib("mixer/include/mixer.hrl").
--mixin([{chef_object,[{default_fetch/2, fetch}]}]).
-
+-mixin([{chef_object,[
+                      {default_fetch/2, fetch},
+                      {default_update/2, update}
+                     ]}]).
 -export([
          list/2
          ]).

--- a/src/chef_node.erl
+++ b/src/chef_node.erl
@@ -54,8 +54,10 @@
         ]).
 
 -include_lib("mixer/include/mixer.hrl").
--mixin([{chef_object,[{default_fetch/2, fetch}]}]).
-
+-mixin([{chef_object,[
+                      {default_fetch/2, fetch},
+                      {default_update/2, update}
+                     ]}]).
 -export([
          list/2
          ]).

--- a/src/chef_object.erl
+++ b/src/chef_object.erl
@@ -34,6 +34,11 @@
                                  ReturnTransform :: tuple()}) ->
                                       select_return()).
 
+-type update_return() :: {ok, 1} | {ok, not_found} | {error, _}.
+
+-type update_callback() :: fun((UpdateQueryName :: atom(), BindParameters :: list()) ->
+                                      update_return()).
+
 
 -callback authz_id(object_rec()) -> object_id().
 -callback is_indexed() -> boolean().
@@ -54,6 +59,8 @@
 -callback record_fields() -> list(atom()).
 -callback list(object_rec(), select_callback()) -> select_return().
 -callback fetch(object_rec(), select_callback()) -> select_return().
+-callback update(object_rec(), update_callback()) ->
+     update_return().
     
 
 -callback new_record(OrgId :: object_id(),
@@ -100,7 +107,9 @@
 
          list/2,
          fetch/2,
-         default_fetch/2
+         update/3,
+         default_fetch/2,
+         default_update/2
         ]).
 
 -export_type([
@@ -198,6 +207,11 @@ fetch(Rec, CallbackFun) ->
     Mod = element(1, Rec),
     Mod:fetch(Rec, CallbackFun).
 
+update(Rec, ActorId, CallbackFun) ->
+    Mod = element(1, Rec),
+    Mod:update(chef_object:set_updated(Rec, ActorId), CallbackFun).
+    
+
 %% Return the callback module for a given object record type. We're putting the abstraction
 %% in place in case we need to do something other than the identity mapping of record name
 %% to callback module name that we're doing there. If we needed to swap in something else,
@@ -218,3 +232,8 @@ default_fetch(Rec, CallbackFun) ->
     CallbackFun({call0(Rec, find_query),
             call(Rec, fields_for_fetch),
             {first_as_record, [element(1, Rec), call0(Rec, record_fields)]}}).
+
+default_update(ObjectRec, CallbackFun) ->
+    QueryName = chef_object:update_query(ObjectRec),
+    UpdatedFields = chef_object:fields_for_update(ObjectRec),
+    CallbackFun(QueryName, UpdatedFields).

--- a/src/chef_object.erl
+++ b/src/chef_object.erl
@@ -36,9 +36,6 @@
 
 -type update_return() :: {ok, 1} | {ok, not_found} | {error, _}.
 
--type update_callback() :: fun((UpdateQueryName :: atom(), BindParameters :: list()) ->
-                                      update_return()).
-
 
 -callback authz_id(object_rec()) -> object_id().
 -callback is_indexed() -> boolean().
@@ -59,7 +56,7 @@
 -callback record_fields() -> list(atom()).
 -callback list(object_rec(), select_callback()) -> select_return().
 -callback fetch(object_rec(), select_callback()) -> select_return().
--callback update(object_rec(), update_callback()) ->
+-callback update(object_rec(), select_callback()) ->
      update_return().
     
 
@@ -236,4 +233,4 @@ default_fetch(Rec, CallbackFun) ->
 default_update(ObjectRec, CallbackFun) ->
     QueryName = chef_object:update_query(ObjectRec),
     UpdatedFields = chef_object:fields_for_update(ObjectRec),
-    CallbackFun(QueryName, UpdatedFields).
+    CallbackFun({QueryName, UpdatedFields}).

--- a/src/chef_role.erl
+++ b/src/chef_role.erl
@@ -52,8 +52,10 @@
         ]).
 
 -include_lib("mixer/include/mixer.hrl").
--mixin([{chef_object,[{default_fetch/2, fetch}]}]).
-
+-mixin([{chef_object,[
+                      {default_fetch/2, fetch},
+                      {default_update/2, update}
+                     ]}]).
 -export([
          list/2
          ]).

--- a/src/chef_user.erl
+++ b/src/chef_user.erl
@@ -52,7 +52,10 @@
         ]).
 
 -include_lib("mixer/include/mixer.hrl").
--mixin([{chef_object,[{default_fetch/2, fetch}]}]).
+-mixin([{chef_object,[
+                      {default_fetch/2, fetch},
+                      {default_update/2, update}
+                     ]}]).
 
 -export([
          list/2


### PR DESCRIPTION
chef_object:update is implemented for basic cases across all 
chef_objects.  More complex implemenations are still handled
by chef_db/chef_sql.
