### PR TITLE
refactor conflict msg into chef_object behaviour

### DIFF
--- a/src/chef_client.erl
+++ b/src/chef_client.erl
@@ -24,6 +24,7 @@
          authz_id/1,
          add_authn_fields/2,
          assemble_client_ejson/2,
+         conflict_message/1,
          ejson_for_indexing/2,
          fields_for_fetch/1,
          fields_for_update/1,
@@ -205,6 +206,10 @@ fields_for_fetch(#chef_client{org_id = OrgId,
 
 record_fields() ->
     record_info(fields, chef_client).
+
+-spec conflict_message(binary()) -> ejson_term().
+conflict_message(_Name) ->
+    {[{<<"error">>, [<<"Client already exists">>]}]}.
 
 -spec add_authn_fields(ejson_term(), binary()) -> ejson_term().
 %% @doc Add in the generated public key along with other authn related

--- a/src/chef_cookbook_version.erl
+++ b/src/chef_cookbook_version.erl
@@ -26,6 +26,7 @@
          assemble_cookbook_ejson/2,
          authz_id/1,
          base_cookbook_name/1,
+         conflict_message/1,
          constraint_map_spec/1,
          ejson_for_indexing/2,
          extract_checksums/1,
@@ -176,6 +177,10 @@ new_record(OrgId, AuthzId, CBVData) ->
                            metadata = Metadata,
                            checksums = extract_checksums(CBVData),
                            serialized_object = Data}.
+
+-spec conflict_message(binary()) -> ejson_term().
+conflict_message(_Name) ->
+    {[{<<"error">>, [<<"Cookbook already exists">>]}]}.
 
 compress_maybe(Data, cookbook_long_desc) ->
     chef_db_compression:compress(cookbook_long_desc, Data);

--- a/src/chef_data_bag.erl
+++ b/src/chef_data_bag.erl
@@ -23,6 +23,7 @@
 
 -export([
          authz_id/1,
+         conflict_message/1,
          ejson_for_indexing/2,
          fields_for_fetch/1,
          fields_for_update/1,
@@ -155,6 +156,11 @@ fields_for_fetch(#chef_data_bag{org_id = OrgId,
 
 record_fields() ->
     record_info(fields, chef_data_bag).
+
+-spec conflict_message(binary()) -> ejson_term().
+conflict_message(_Name) ->
+    %% {[{<<"error">>, [<<"Data Bag '", Name/binary, "' already exists">>]}]}.
+    {[{<<"error">>, [<<"Data bag already exists">>]}]}.
 
 %% @doc Convert a binary JSON string representing a Chef data_bag into an EJson-encoded
 %% Erlang data structure.

--- a/src/chef_data_bag_item.erl
+++ b/src/chef_data_bag_item.erl
@@ -25,6 +25,7 @@
 -export([
          add_type_and_bag/2,
          authz_id/1,
+         conflict_message/1,
          ejson_for_indexing/2,
          is_indexed/0,
          fields_for_fetch/1,
@@ -165,6 +166,12 @@ fields_for_fetch(#chef_data_bag_item{org_id = OrgId,
 
 record_fields() ->
     record_info(fields, chef_data_bag_item).
+
+-spec conflict_message({binary(), binary()}) -> ejson_term().
+conflict_message({BagName, ItemName}) ->
+    Msg = <<"Data Bag Item '", ItemName/binary, "' already exists in Data Bag '",
+            BagName/binary, "'.">>,
+    {[{<<"error">>, [Msg]}]}.
 
 -spec add_type_and_bag(BagName :: binary(), Item :: ejson_term()) -> ejson_term().
 %% @doc Returns data bag item EJSON `Item' with keys `chef_type' and `data_bag' added.

--- a/src/chef_environment.erl
+++ b/src/chef_environment.erl
@@ -24,6 +24,7 @@
 
 -export([
          authz_id/1,
+         conflict_message/1,
          ejson_for_indexing/2,
          fields_for_fetch/1,
          fields_for_update/1,
@@ -217,3 +218,7 @@ record_fields() ->
 
 list(#chef_environment{org_id = OrgId}, CallbackFun) ->
     CallbackFun({list_query(), [OrgId], [name]}).
+
+-spec conflict_message(binary()) -> ejson_term().
+conflict_message(_Name) ->
+    {[{<<"error">>, [<<"Environment already exists">>]}]}.

--- a/src/chef_node.erl
+++ b/src/chef_node.erl
@@ -23,6 +23,7 @@
 
 -export([
          authz_id/1,
+         conflict_message/1,
          ejson_for_indexing/2,
          extract_recipes/1,
          extract_roles/1,
@@ -215,6 +216,11 @@ fields_for_fetch(#chef_node{org_id = OrgId,
 
 record_fields() ->
     record_info(fields, chef_node).
+
+-spec conflict_message(binary()) -> ejson_term().
+conflict_message(_Name) ->
+    Msg = <<"Node already exists">>,
+    {[{<<"error">>, [Msg]}]}.
 
 extract_recipes(RunList) ->
     [ binary:part(Item, {0, byte_size(Item) - 1})

--- a/src/chef_object.erl
+++ b/src/chef_object.erl
@@ -79,6 +79,9 @@
 -callback type_name(object_rec()) ->
     atom().
 
+-callback conflict_message(binary() | {binary(), binary()}) ->
+    ejson_term().
+
 -export([
          authz_id/1,
          set_created/2,
@@ -106,7 +109,9 @@
          fetch/2,
          update/3,
          default_fetch/2,
-         default_update/2
+         default_update/2,
+
+         conflict_message/2
         ]).
 
 -export_type([
@@ -234,3 +239,8 @@ default_update(ObjectRec, CallbackFun) ->
     QueryName = chef_object:update_query(ObjectRec),
     UpdatedFields = chef_object:fields_for_update(ObjectRec),
     CallbackFun({QueryName, UpdatedFields}).
+
+-spec conflict_message(object_rec(), binary() | {binary(), binary()}) -> ejson_term().
+conflict_message(Rec, Name) ->
+    Mod = callback_mod(Rec),
+    Mod:conflict_message(Name).

--- a/src/chef_role.erl
+++ b/src/chef_role.erl
@@ -24,6 +24,7 @@
 
 -export([
          authz_id/1,
+         conflict_message/1,
          ejson_for_indexing/2,
          fields_for_fetch/1,
          fields_for_update/1,
@@ -281,3 +282,6 @@ record_fields() ->
 list(#chef_role{org_id = OrgId}, CallbackFun) ->
     CallbackFun({list_query(), [OrgId], [name]}).
 
+-spec conflict_message(binary()) -> ejson_term().
+conflict_message(_Name) ->
+    {[{<<"error">>, [<<"Role already exists">>]}]}.


### PR DESCRIPTION
The conflict message display was handled in the `chef_wm_base` module. This refactors the multi-fun-head implementation into the `chef_object` behaviour implementation.

/cc @seth @oferrigni 
