### PR TITLE
add callback for object rename support

### DIFF
--- a/src/chef_client.erl
+++ b/src/chef_client.erl
@@ -41,6 +41,7 @@
          parse_binary_json/2,
          parse_binary_json/3,
          record_fields/0,
+         rename_supported/0,
          set_created/2,
          set_updated/2,
          type_name/1,
@@ -205,6 +206,9 @@ fields_for_fetch(#chef_client{org_id = OrgId,
 
 record_fields() ->
     record_info(fields, chef_client).
+
+rename_supported() ->
+    true.
 
 -spec add_authn_fields(ejson_term(), binary()) -> ejson_term().
 %% @doc Add in the generated public key along with other authn related

--- a/src/chef_cookbook_version.erl
+++ b/src/chef_cookbook_version.erl
@@ -41,6 +41,7 @@
          parse_version/1,
          qualified_recipe_names/2,
          record_fields/0,
+         rename_supported/0,
          set_created/2,
          set_updated/2,
 
@@ -176,6 +177,9 @@ new_record(OrgId, AuthzId, CBVData) ->
                            metadata = Metadata,
                            checksums = extract_checksums(CBVData),
                            serialized_object = Data}.
+
+rename_supported() ->
+    false.
 
 compress_maybe(Data, cookbook_long_desc) ->
     chef_db_compression:compress(cookbook_long_desc, Data);

--- a/src/chef_data_bag.erl
+++ b/src/chef_data_bag.erl
@@ -33,6 +33,7 @@
          new_record/3,
          parse_binary_json/2,
          record_fields/0,
+         rename_supported/0,
          set_created/2,
          set_updated/2,
          type_name/1,
@@ -155,6 +156,9 @@ fields_for_fetch(#chef_data_bag{org_id = OrgId,
 
 record_fields() ->
     record_info(fields, chef_data_bag).
+
+rename_supported() ->
+    false.
 
 %% @doc Convert a binary JSON string representing a Chef data_bag into an EJson-encoded
 %% Erlang data structure.

--- a/src/chef_data_bag_item.erl
+++ b/src/chef_data_bag_item.erl
@@ -35,6 +35,7 @@
          new_record/3,
          parse_binary_json/2,
          record_fields/0,
+         rename_supported/0,
          set_created/2,
          set_updated/2,
          type_name/1,
@@ -165,6 +166,9 @@ fields_for_fetch(#chef_data_bag_item{org_id = OrgId,
 
 record_fields() ->
     record_info(fields, chef_data_bag_item).
+
+rename_supported() ->
+    false.
 
 -spec add_type_and_bag(BagName :: binary(), Item :: ejson_term()) -> ejson_term().
 %% @doc Returns data bag item EJSON `Item' with keys `chef_type' and `data_bag' added.

--- a/src/chef_environment.erl
+++ b/src/chef_environment.erl
@@ -34,6 +34,7 @@
          new_record/3,
          parse_binary_json/1,
          record_fields/0,
+         rename_supported/0,
          set_created/2,
          set_default_values/1,
          set_updated/2,
@@ -217,3 +218,6 @@ record_fields() ->
 
 list(#chef_environment{org_id = OrgId}, CallbackFun) ->
     CallbackFun({list_query(), [OrgId], [name]}).
+
+rename_supported() ->
+    false.

--- a/src/chef_node.erl
+++ b/src/chef_node.erl
@@ -36,6 +36,7 @@
          new_record/3,
          parse_check_binary_as_json_node/2,
          record_fields/0,
+         rename_supported/0,
          set_created/2,
          set_updated/2,
          type_name/1,
@@ -215,6 +216,9 @@ fields_for_fetch(#chef_node{org_id = OrgId,
 
 record_fields() ->
     record_info(fields, chef_node).
+
+rename_supported() ->
+    false.
 
 extract_recipes(RunList) ->
     [ binary:part(Item, {0, byte_size(Item) - 1})

--- a/src/chef_object.erl
+++ b/src/chef_object.erl
@@ -79,6 +79,8 @@
 -callback type_name(object_rec()) ->
     atom().
 
+-callback rename_supported() -> true | false.
+
 -export([
          authz_id/1,
          set_created/2,
@@ -106,7 +108,9 @@
          fetch/2,
          update/3,
          default_fetch/2,
-         default_update/2
+         default_update/2,
+
+         rename_supported/1
         ]).
 
 -export_type([
@@ -234,3 +238,7 @@ default_update(ObjectRec, CallbackFun) ->
     QueryName = chef_object:update_query(ObjectRec),
     UpdatedFields = chef_object:fields_for_update(ObjectRec),
     CallbackFun({QueryName, UpdatedFields}).
+
+-spec rename_supported(object_rec()) -> true | false.
+rename_supported(Rec) ->
+    call0(Rec, rename_supported).

--- a/src/chef_role.erl
+++ b/src/chef_role.erl
@@ -35,6 +35,7 @@
          org_id/1,
          parse_binary_json/2,
          record_fields/0,
+         rename_supported/0,
          set_created/2,
          set_updated/2,
          type_name/1,
@@ -281,3 +282,5 @@ record_fields() ->
 list(#chef_role{org_id = OrgId}, CallbackFun) ->
     CallbackFun({list_query(), [OrgId], [name]}).
 
+rename_supported() ->
+    false.


### PR DESCRIPTION
I've added a callback to determine whether objects support rename. I'm not 100% sure that this belongs here as opposed to the resource modules in chef_wm / oc_chef_wm.

/cc @seth @oferrigni 
