### PR TITLE
Revert "use built-in erlang:port_info to get os proc id"

### DIFF
--- a/priv/depselector_rb/depselector.rb
+++ b/priv/depselector_rb/depselector.rb
@@ -31,6 +31,11 @@ def constraint_to_str(constraint, constraint_version)
 end
 
 receive do |m|
+  m.when([:get_pid]) do
+    m.send!(Process.pid)
+    m.receive_loop
+  end
+
   m.when([:solve, Erl.hash]) do |data|
     begin
       # create dependency graph from cookbooks

--- a/src/chef_depsolver_worker.erl
+++ b/src/chef_depsolver_worker.erl
@@ -118,7 +118,13 @@ init([]) ->
     %% info on startup so that we can use it in the event of a timeout. Hard-killing the process
     %% handles the failure case where the Ruby process gets hung and can no longer respond to
     %% STDOUT closing, which would typically cause the process to exit.
-    {os_pid, Pid} = erlang:port_info(Port, os_pid),
+    Payload = term_to_binary({get_pid}),
+    erlang:port_command(Port, Payload),
+    Pid = receive
+              {Port, {data, Data}} ->
+                  binary_to_term(Data)
+          end,
+
     {ok, #state{port=Port, os_pid=Pid}}.
 
 %%--------------------------------------------------------------------
@@ -154,7 +160,7 @@ handle_call({solve, AllVersions, EnvConstraints, Cookbooks, Timeout},
     %%
     %% If we do reach the Erlang-level receive timeout, then we want to
     %% force-kill the ruby process. We handle the erlang timeout with
-    %% a force-kill because there is a chance that the ruby process is
+    %% a forve-kill because there is a chance that the ruby process is
     %% hung and will not be able to respond to stdout closing and clean
     %% itself up. If, instead, the ruby process returns the timeout message,
     %% we know that it remains in a state to respond to further requests


### PR DESCRIPTION
This reverts commit e9d448efbcb15d22b0e706c4ff0d2b6e26e93f35.
port_info does not support os_pid until R15B02, and we're still on
R15B01.

/cc  @sdelano @seth  - reverts to the original fix, I'll be merging momentarily. 
