### PR TITLE
Align api to reflect new_record usage

### DIFF
--- a/src/chef_data_bag_item.erl
+++ b/src/chef_data_bag_item.erl
@@ -119,13 +119,16 @@ set_updated(#chef_data_bag_item{} = Object, ActorId) ->
 is_indexed() ->
     true.
 
--spec ejson_for_indexing(#chef_data_bag_item{}, ejson_term()) -> ejson_term().
+-spec ejson_for_indexing(#chef_data_bag_item{}, {binary, ejson_term()} | ejson_term()) -> ejson_term().
+ejson_for_indexing(#chef_data_bag_item{} = BagItem, {_BagName, Item}) when is_binary(_BagName) ->
+    ejson_for_indexing(BagItem, Item);
 ejson_for_indexing(#chef_data_bag_item{data_bag_name = BagName,
                                        item_name = ItemName}, Item) ->
     %% See Chef::DataBagItem#to_hash
     %% We basically set data_bag and chef_type key against the original data bag item.
     ItemName = ej:get({<<"id">>}, Item),
     ej:set({<<"data_bag">>}, ej:set({<<"chef_type">>}, Item, <<"data_bag_item">>), BagName).
+
 
 -spec update_from_ejson(#chef_data_bag_item{}, ejson_term()) -> #chef_data_bag_item{}.
 update_from_ejson(#chef_data_bag_item{} = DataBagItem, DataBagItemData) ->

--- a/test/chef_data_bag_item_tests.erl
+++ b/test/chef_data_bag_item_tests.erl
@@ -66,6 +66,18 @@ ejson_for_indexing_test() ->
     Got = chef_object:ejson_for_indexing(Item, RawItem),
     ?assertEqual(Expected, Got).
 
+ejson_for_indexing_api_conformance_test() ->
+    RawItem = {[{<<"id">>, <<"the_item_name">>},
+                {<<"a_key">>, <<"a_value">>}]},
+    Item = #chef_data_bag_item{data_bag_name = <<"the_bag_name">>,
+                               item_name = <<"the_item_name">>},
+    Expected = {[{<<"id">>, <<"the_item_name">>},
+                 {<<"a_key">>, <<"a_value">>},
+                 {<<"chef_type">>, <<"data_bag_item">>},
+                 {<<"data_bag">>, <<"the_bag_name">>}]},
+    Got = chef_object:ejson_for_indexing(Item, {<<"the_bag_name">>, RawItem}),
+    ?assertEqual(Expected, Got).
+
 update_from_ejson_test_() ->
     RawItem = {[{<<"id">>, <<"the_item_name">>},
                 {<<"a_key">>, <<"a_value">>}]},


### PR DESCRIPTION
This aligns usage of the ejson tuple between new_record and ejson_for_indexing.
