### PR TITLE
Dialyzer Fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 DEPS = $(CURDIR)/deps
 
-DIALYZER_OPTS = -Wunderspecs
+DIALYZER_OPTS =
 
 DIALYZER_DEPS = deps/chef_authn/ebin \
                 deps/ej/ebin \

--- a/src/chef_user.erl
+++ b/src/chef_user.erl
@@ -108,7 +108,8 @@ username_from_ejson(UserData) ->
             Name
     end.
 
--spec new_record(object_id(), object_id(), ejson_term() | {ejson_term(), {binary(), binary(), binary()}}) -> #chef_user{}.
+-spec new_record(object_id(), object_id(),
+        ejson_term() | {ejson_term(), {binary() | null, binary() | null, binary() | null}}) -> #chef_user{}.
 new_record(OrgId, AuthzId, {UserData, {HashPass, Salt, HashType}}) ->
     Name = username_from_ejson(UserData),
     Id = chef_object_base:make_org_prefix_id(OrgId, Name),


### PR DESCRIPTION
My first checkout of master returned the following dialyzer errors:

```
chef_user.erl:135: The call chef_user:new_record(OrgId::any(),AuthzId::any(),{_,{'null','null','null'}}) breaks the contract (object_id(),object_id(),ejson_term() | {ejson_term(),{binary(),binary(),binary()}}) -> #chef_user{}
chef_user.erl:325: Type specification chef_user:update_from_ejson(#chef_user{},ejson_term()) -> #chef_user{} is a supertype of the success typing: chef_user:update_from_ejson(#chef_user{pubkey_version::'undefined' | 0 | 1},{[any()]}) -> #chef_user{pubkey_version::'undefined' | 0 | 1}
```

The first was an easy spec change.

The second was just dialyzer being dialyzer, but we're able to give that one a free pass by removing `-Wunderspec`
