### PR TITLE
Default external-authentication-uid to null on update

### DIFF
--- a/src/chef_user.erl
+++ b/src/chef_user.erl
@@ -328,8 +328,8 @@ set_password_data(#chef_user{}=User, {HashedPassword, Salt, HashType}) ->
 update_from_ejson(#chef_user{} = User, UserEJson) ->
     Name = username_from_ejson(UserEJson),
     Email = ej:get({<<"email">>}, UserEJson),
-    ExternalAuthenticationUid = ej:get({<<"external_authentication_uid">>}, UserEJson),
-    RecoveryAuthenticationEnabled = ej:get({<<"recovery_authentication_enabled">>}, UserEJson),
+    ExternalAuthenticationUid = value_or_null({<<"external_authentication_uid">>}, UserEJson),
+    RecoveryAuthenticationEnabled = ej:get({<<"recovery_authentication_enabled">>}, UserEJson) =:= true,
     {Key, Version} = chef_object_base:cert_or_key(UserEJson),
 
     User1 = case Key of

--- a/test/chef_user_tests.erl
+++ b/test/chef_user_tests.erl
@@ -182,8 +182,22 @@ update_record_test() ->
                         {<<"public_key">>, public_key_data()} ]},
     NewUser = chef_user:update_from_ejson(User,  UpdateAsEJson),
     ?assertMatch(#chef_user{}, NewUser),
-    ?assertEqual(<<"martha">>, chef_user:name(NewUser)).
+    ?assertEqual(<<"martha">>, chef_user:name(NewUser)),
+    ?assertEqual(null, NewUser#chef_user.external_authentication_uid),
+    ?assertEqual(false, NewUser#chef_user.recovery_authentication_enabled).
 
+update_record_with_valid_ext_auth_data_test() ->
+    SerializedAsEJson = {base_user_record_as_ejson() ++ persisted_serializable_fields()},
+    User = make_valid_user_record(chef_json:encode(SerializedAsEJson)),
+    UserData = {[ {<<"username">>, <<"martha">>},
+                  {<<"email">>, <<"new_email">>},
+                  {<<"display_name">>, <<"martha stewart pony">>},
+                  {<<"external_authentication_uid">>, <<"bob">>},
+                  {<<"recovery_authentication_enabled">>, true}
+    ]},
+    NewUser = chef_user:update_from_ejson(User,  UserData),
+    ?assertEqual(<<"bob">>, NewUser#chef_user.external_authentication_uid),
+    ?assertEqual(true, NewUser#chef_user.recovery_authentication_enabled).
 
 new_record_test() ->
     UserData = {[
@@ -198,7 +212,9 @@ new_record_test() ->
     Password = {Hashed, Salt, HashType},
     User = chef_user:new_record(OrgId, AuthzId, {UserData, Password}),
     ?assertMatch(#chef_user{}, User),
-    ?assertEqual(<<"bob">>, chef_user:name(User)).
+    ?assertEqual(<<"bob">>, chef_user:name(User)),
+    ?assertEqual(null, User#chef_user.external_authentication_uid),
+    ?assertEqual(false, User#chef_user.recovery_authentication_enabled).
 
 public_key_data() ->
     <<"-----BEGIN PUBLIC KEY-----\nMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCyVPW9YXa5PR0rgEW1updSxygB\nwmVpDnHurgQ7/gbh+PmY49EZsfrZSbKgSKy+rxdsVoSoU+krYtHvYIwVfr2tk0FP\nnhAWJaFH654KpuCNG6x6iMLtzGO1Ma/VzHnFqoOeSCKHXDhmHwJAjGDTPAgCJQiI\neau6cDNJRiJ7j0/xBwIDAQAB\n-----END PUBLIC KEY-----">>.


### PR DESCRIPTION
Looks like the last trailing edge - when a user was updaetd via PUT, the value "undefined" was getting captured for `external_authentication_uid`.  This fixes that.   This also provides consistent behavior with new_record re: recovery-auth-enabled, by forcing the value to true/false.

ping @opscode/server-team 
