### PR TITLE
Fix for OC-11422

### DIFF
--- a/src/chef_cookbook_version.erl
+++ b/src/chef_cookbook_version.erl
@@ -343,7 +343,7 @@ is_valid_version(Version) ->
 %% @doc Given a binary parse it to a valid cookbook version tuple {Major, Minor, Patch} or
 %% raise a `badarg' error. Each of `Major', `Minor', and `Patch' must be non-negative
 %% integer values less than 2147483647 (max size of value in pg int column). It is
-%% acceptable to provide a value with zero, one, or two dots (1 is the same as 1.0.0). More
+%% acceptable to provide a value with one or two dots (1 is the same as 1.0.0). More
 %% than two dots is an error.
 %%
 %% @end
@@ -364,8 +364,7 @@ parse_version(Version) when is_binary(Version) ->
             error(badarg)
     end.
 
-normalize_version([X]) ->
-    [X, 0, 0];
+
 normalize_version([X, Y]) ->
     [X, Y, 0];
 normalize_version([_, _, _] = V) ->

--- a/src/chef_cookbook_version.erl
+++ b/src/chef_cookbook_version.erl
@@ -343,8 +343,8 @@ is_valid_version(Version) ->
 %% @doc Given a binary parse it to a valid cookbook version tuple {Major, Minor, Patch} or
 %% raise a `badarg' error. Each of `Major', `Minor', and `Patch' must be non-negative
 %% integer values less than 2147483647 (max size of value in pg int column). It is
-%% acceptable to provide a value with one or two dots (1 is the same as 1.0.0). More
-%% than two dots is an error.
+%% acceptable to provide a value with one or two dots (1.0 is the same as 1.0.0). Less 
+%% than one dot or more than two dots is an error.
 %%
 %% @end
 -spec parse_version(Version::binary()) -> {Major::non_neg_integer(),

--- a/test/chef_cookbook_version_tests.erl
+++ b/test/chef_cookbook_version_tests.erl
@@ -229,13 +229,10 @@ version_to_binary_test() ->
     ?assertEqual(<<"0.0.1">>, chef_cookbook_version:version_to_binary({0,0,1})).
 
 parse_version_test_() ->
-    GoodVersions = [{<<"0">>, {0, 0, 0}},
-                    {<<"1">>, {1, 0, 0}},
-                    {<<"1.2">>, {1, 2, 0}},
+    GoodVersions = [{<<"1.2">>, {1, 2, 0}},
                     {<<"1.2.3">>, {1, 2, 3}},
                     {<<"1.2.", ?MAX_GOOD_VERSION>>, {1,2, ?MAX_GOOD_VERSION_INT}},
                     {<<"1.", ?MAX_GOOD_VERSION>>, {1, ?MAX_GOOD_VERSION_INT, 0}},
-                    {<<?MAX_GOOD_VERSION>>, {?MAX_GOOD_VERSION_INT, 0, 0}},
                     {<<?MAX_GOOD_VERSION, ".0">>, {?MAX_GOOD_VERSION_INT, 0, 0}},
                     {<<"0.",?MAX_GOOD_VERSION,".0">>, {0, ?MAX_GOOD_VERSION_INT, 0}},
                     {<<"0.0.0">>, {0, 0, 0}},
@@ -245,6 +242,9 @@ parse_version_test_() ->
 
 parse_version_badversion_test_() ->
     BadVersions = [
+                   <<"0">>,
+                   <<"1">>,
+                   <<?MAX_GOOD_VERSION>>,
                    <<"">>,
                    <<"A">>,
                    <<"1.2.a">>,


### PR DESCRIPTION
No longer allow single integer version numbers for dependencies on the server side.

Please see [OC-11422](https://tickets.corp.opscode.com/browse/OC-11422) for more information.

Tests: https://github.com/opscode/chef-pedant/pull/74
