### PR TITLE
move chef_wm/chef_wm_password to chef_objects/chef_password

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ DIALYZER_DEPS = deps/chef_authn/ebin \
                 deps/ej/ebin \
                 deps/jiffy/ebin \
                 deps/ibrowse/ebin \
+                deps/bcrypt/ebin \
                 deps/mini_s3/ebin
 
 DEPS_PLT = chef_objects.plt

--- a/rebar.config
+++ b/rebar.config
@@ -20,6 +20,8 @@
          {git, "git://github.com/opscode/opscoderl_folsom.git", {branch, "master"}}},
         {pooler, ".*",
          {git, "git://github.com/seth/pooler.git", {tag, "1.0.0"}}},
+        {bcrypt, ".*",
+         {git, "git://github.com/opscode/erlang-bcrypt.git", {tag, "0.5.0.3"}}},
         {mixer, ".*",
          {git, "git://github.com/opscode/mixer.git", {tag, "0.1.1"}}},
         {envy, ".*",

--- a/src/chef_objects.app.src
+++ b/src/chef_objects.app.src
@@ -23,6 +23,8 @@
   {applications, [
                   kernel,
                   stdlib,
+                  crypto,
+                  bcrypt,
                   ibrowse,
                   folsom,
                   pooler

--- a/src/chef_password.erl
+++ b/src/chef_password.erl
@@ -69,14 +69,13 @@ upgrade(Password, {_OldHash, _OldSalt, _AnyType}) ->
 %% pure bcrypt.  It is expected that clients will call 'upgrade' upon successful
 %% authentication and save the resulting password hash data if it has changed.
 -spec verify(str_or_bin(), password_data()) -> boolean().
-verify(Password, {HashedPass,<<"">>, ?DEFAULT_HASH_TYPE}) ->
-    % the bcrypt library will automatically use the salt portion of the hashed password
-    % string, so pass the entire thing as the salt value.
-    verify(Password, {HashedPass, HashedPass, ?DEFAULT_HASH_TYPE});
 verify(Password, {HashedPass, Salt, ?OSC_DEFAULT_HASH_TYPE}) ->
     verify(Password, {HashedPass, Salt, ?DEFAULT_HASH_TYPE});
-verify(Password, {HashedPass, Salt, ?DEFAULT_HASH_TYPE}) ->
-    {ok, ThisHashedPass} = bcrypt:hashpw(to_str(Password), to_str(Salt)),
+verify(Password, {HashedPass, _, ?DEFAULT_HASH_TYPE}) ->
+    % the bcrypt library will automatically use the salt portion of the hashed password
+    % string, so for bcrypt-encoded passwords we will provided the hashed password as the
+    % salt value as well.
+    {ok, ThisHashedPass} = bcrypt:hashpw(to_str(Password), to_str(HashedPass)),
     slow_compare(ThisHashedPass, to_str(HashedPass));
 verify(Password, {HashedPass, Salt, ?MIGRATION_HASH_TYPE}) ->
     InterimPass = sha1(Salt, Password, ec),

--- a/src/chef_password.erl
+++ b/src/chef_password.erl
@@ -1,0 +1,132 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92-*-
+%% ex: ts=4 sw=4 et
+%% @author Seth Falcon <seth@getchef.com>
+%% @author Marc Paradise <marc@getchef.com>
+%% Copyright 2012-14 Chef Software, Inc. All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+-module(chef_password).
+
+-export([encrypt/1,
+         upgrade/2,
+         verify/2]).
+
+-ifdef(TEST).
+-compile([export_all]).
+-endif.
+
+-define(DEFAULT_HASH_TYPE, <<"bcrypt">>).
+-define(MIGRATION_HASH_TYPE, <<"SHA1-bcrypt">>).
+
+-define(OSC_DEFAULT_HASH_TYPE, <<"erlang-bcrypt-0.5.0">>).
+-define(OSC_MIGRATION_HASH_TYPE, <<"sha1+bcrypt">>).
+
+-type str_or_bin() :: string() | binary().
+-type password_data() :: { binary(),  binary(), binary() }.
+
+%% @doc Return hashed password, salt, and hash type. Uses bcrypt with
+%% the number of rounds as configured in the bcrypt application key
+%% `default_log_rounds'. It is an error to attempt to hash an empty
+%% password, but no other restrictions are placed on the password.
+-spec encrypt(str_or_bin()) -> password_data().
+encrypt(Empty) when Empty =:= "";
+                    Empty =:= <<"">> ->
+    erlang:error({invalid_password, Empty});
+encrypt(Password) ->
+    {ok, Salt} = bcrypt:gen_salt(),
+    {ok, HashedPass} = bcrypt:hashpw(to_str(Password), Salt),
+    {list_to_binary(HashedPass), list_to_binary(Salt), ?DEFAULT_HASH_TYPE}.
+
+%% @doc if required, upgrade password encryption from SHA1 or migration type (OSC or EC)
+%% to bcrypt.
+%% Returns a password_data() tuple which will differ from the input
+%% only if a password encryption upgrade was required.
+-spec upgrade(str_or_bin(), password_data()) -> password_data().
+upgrade(_Password, {HashedPass, Salt, ?DEFAULT_HASH_TYPE = Type}) ->
+    {HashedPass, Salt, Type};
+upgrade(Password, {_OldHash, _OldSalt, _AnyType}) ->
+    % If the passowrd is not currently hashed via DEFAULT_HASH_TYPE,
+    % we're going to upgrade it - regardless of whether it's
+    % using a migrated hash type, or completely unconverted.
+    encrypt(Password).
+
+%% @doc Return `true' if the plain password hashes to the same value
+%% using the specified hash type and salt. This supports multiple encoding schemas:
+%% plain sha1+salt, OSC-migration/transitional, EC-migration/transitional, and
+%% pure bcrypt.  It is expected that clients will call 'upgrade' upon successful
+%% authentication and save the resulting password hash data if it has changed.
+-spec verify(str_or_bin(), password_data()) -> boolean().
+verify(Password, {HashedPass,<<"">>, ?DEFAULT_HASH_TYPE}) ->
+    % the bcrypt library will automatically use the salt portion of the hashed password
+    % string, so pass the entire thing as the salt value.
+    verify(Password, {HashedPass, HashedPass, ?DEFAULT_HASH_TYPE});
+verify(Password, {HashedPass, Salt, ?OSC_DEFAULT_HASH_TYPE}) ->
+    verify(Password, {HashedPass, Salt, ?DEFAULT_HASH_TYPE});
+verify(Password, {HashedPass, Salt, ?DEFAULT_HASH_TYPE}) ->
+    {ok, ThisHashedPass} = bcrypt:hashpw(to_str(Password), to_str(Salt)),
+    slow_compare(ThisHashedPass, to_str(HashedPass));
+verify(Password, {HashedPass, Salt, ?MIGRATION_HASH_TYPE}) ->
+    InterimPass = sha1(Salt, Password, ec),
+    {ok, ThisHashedPass} = bcrypt:hashpw(to_str(InterimPass), to_str(HashedPass)),
+    slow_compare(ThisHashedPass, to_str(HashedPass));
+verify(Password, {HashedPass, Salt, ?OSC_MIGRATION_HASH_TYPE}) ->
+    {OrigSalt, BcryptSalt} = parse_salt(Salt),
+    SHA = sha1(OrigSalt, Password, osc),
+    {ok, ThisHashedPass} = bcrypt:hashpw(SHA, BcryptSalt),
+    slow_compare(ThisHashedPass, to_str(HashedPass));
+verify(Password, {HashedPass, Salt, _}) ->
+    % Support unconverted passwords too, for existing installations that have
+    % not been upgraded in any way.
+    ThisHashedPass = sha1(Salt, Password, ec),
+    case slow_compare(ThisHashedPass, to_str(HashedPass)) of
+        true ->
+            true;
+        false ->
+            ThisHashedPass2 = sha1(Salt, Password, osc),
+            slow_compare(ThisHashedPass2, to_str(HashedPass))
+    end.
+
+sha1(Salt, Password, osc) ->
+    hexstring(crypto:sha(["--", Salt, "--", Password, "--"]));
+sha1(Salt, Password, ec) ->
+    hexstring(crypto:sha([Salt, "--", Password, "--"])).
+
+hexstring(<<X:160/big-unsigned-integer>>) ->
+    lists:flatten(io_lib:format("~40.16.0b", [X])).
+
+%% Using straight `=:=' could provide an opening for a timing attack
+%% since shared prefix strings will take longer to determine unequal
+%% than not.
+slow_compare(S1, S2) when length(S1) =:= length(S2) ->
+    lists:foldl(fun({X, X}, Acc) ->
+                        Acc;
+                   ({_, _}, _Acc) ->
+                        false
+                end,
+                true,
+                lists:zip(S1, S2));
+slow_compare(_, _) ->
+    false.
+
+parse_salt(Salt) ->
+    [BcryptSalt, OrigSalt] = re:split(Salt, "\t", [{return, list}]),
+    {OrigSalt, BcryptSalt}.
+
+to_str(S) when is_list(S) ->
+    S;
+to_str(S) when is_binary(S) ->
+    binary_to_list(S).
+

--- a/test/chef_password_tests.erl
+++ b/test/chef_password_tests.erl
@@ -1,0 +1,211 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92-*-
+%% ex: ts=4 sw=4 et
+%% @author Seth Falcon <seth@opscode.com>
+%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+
+-module(chef_password_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(OSC_DEFAULT_HASH_TYPE, <<"erlang-bcrypt-0.5.0">>).
+-define(OSC_MIGRATION_HASH_TYPE, <<"sha1+bcrypt">>).
+-define(DEFAULT_HASH_TYPE, <<"bcrypt">>).
+-define(MIGRATION_HASH_TYPE, <<"SHA1-bcrypt">>).
+
+encrypt_test_() ->
+    {setup,
+     fun test_utils:bcrypt_setup/0,
+     fun test_utils:bcrypt_cleanup/1,
+     [{"encrypts a password",
+       fun() ->
+               {Hashed, Salt, Type} = chef_password:encrypt("fizzbuzz"),
+               [ ?assert(is_binary(B)) || B <- [Hashed, Salt, Type] ]
+       end},
+
+      {"empty password not allowed",
+       fun() ->
+               ?assertError({invalid_password, ""}, chef_password:encrypt("")),
+               ?assertError({invalid_password, <<"">>}, chef_password:encrypt(<<"">>))
+       end}
+
+     ]}.
+
+bcrypt_round_trip_test_() ->
+    {setup,
+     fun test_utils:bcrypt_setup/0,
+     fun test_utils:bcrypt_cleanup/1,
+     [
+      {"basic roundtrip", generator,
+       fun() ->
+               Passwords = [<<"a">>, <<"a long password">>, "string123"],
+               PassData = [ {P, chef_password:encrypt(P)} || P <- Passwords ],
+               [ ?_assertEqual(true, chef_password:verify(P, Data))
+                 || {P, Data} <- PassData ]
+       end},
+
+      {"salt not specified roundtrip",
+       fun() ->
+               P = "a long password",
+               {Hash, _, Type} = chef_password:encrypt(P),
+               ?assertEqual(true, chef_password:verify(P, {Hash, <<>>, Type}))
+       end},
+
+      {"wrong password is wrong",
+       fun() ->
+               ?assertEqual(false,
+                            chef_password:verify("two",
+                                                    chef_password:encrypt("one")))
+       end}
+
+     ]}.
+
+cross_type_test_() ->
+    {setup,
+     fun test_utils:bcrypt_setup/0,
+     fun test_utils:bcrypt_cleanup/1,
+     [
+      {"treats a OSC_DEFAULT_HASH_TYPE as a DEFAULT_HASH_TYPE",
+       fun() ->
+            {Hash, Salt, ?DEFAULT_HASH_TYPE} = chef_password:encrypt("a password for me"),
+            ?assertEqual(true, chef_password:verify("a password for me",
+                                                       {Hash, Salt, ?OSC_DEFAULT_HASH_TYPE}))
+       end}
+     ]}.
+
+unmigrated_round_trip_test_() ->
+    {setup,
+     fun() ->
+             test_utils:bcrypt_setup(),
+             osc_sha1_examples() ++ ec_sha1_examples()
+     end,
+     fun test_utils:bcrypt_cleanup/1,
+     fun(Examples) ->
+             [
+
+              [ ?_assertEqual(true, chef_password:verify(Pass, {Hash, Salt, null}))
+                || {Pass, Hash, Salt} <- Examples]
+              ]
+     end}.
+
+migrated_round_trip_test_() ->
+    {setup,
+     fun() ->
+            test_utils:bcrypt_setup(),
+            osc_migrated_examples() ++ ec_migrated_examples()
+     end,
+     fun test_utils:bcrypt_cleanup/1,
+     fun(MigratedExamples) ->
+             [
+              [ ?_assertEqual(true, chef_password:verify(Pass, Prev))
+                || {Pass, Prev} <- MigratedExamples ],
+
+              {"wrong password is wrong",
+               fun() ->
+                       {_, DbData} = hd(MigratedExamples),
+                       WrongPass = "not the password",
+                       ?assertEqual(false, chef_password:verify(WrongPass, DbData))
+               end}
+              ]
+     end}.
+
+upgrade_test_() ->
+    {setup,
+     fun test_utils:bcrypt_setup/0,
+     fun test_utils:bcrypt_cleanup/1,
+     [
+       {"upgrades password data when current form is sha1", generator,
+       fun() ->
+            Data = [hd(osc_sha1_examples())] ++ [hd(ec_sha1_examples())],
+            [ ?_assertMatch({_, _, ?DEFAULT_HASH_TYPE}, chef_password:upgrade(Password, {Hash, Salt, null})) ||
+                             {Password, Hash, Salt} <- Data ]
+
+       end},
+       {"does not upgrade a password when current form is bcrypt",
+       fun() ->
+            Password = "a password for me",
+            Original = chef_password:encrypt(Password),
+            ?assertEqual(Original, chef_password:upgrade(Password, Original))
+       end}
+     ]}.
+
+
+slow_compare_test_() ->
+    Tests = [
+             %% positive cases
+             {{"abc", "abc"}, true},
+             {{"", ""}, true},
+             {{"a", "a"}, true},
+             {{"aaaaaa", "aaaaaa"}, true},
+             %% negative cases
+             {{"a", "b"}, false},
+             {{"abc", "aXc"}, false},
+             {{"abc", "abX"}, false},
+             {{"abX", "abc"}, false},
+             {{"", "a"}, false},
+             {{"a", ""}, false},
+             {{"abc", "abc123"}, false}],
+    [ ?_assertEqual(Expect, chef_password:slow_compare(A, B))
+      || {{A, B}, Expect} <- Tests ].
+
+%% Example data generated with password_gen.rb
+%% Format is {Password, HashedPass, Salt}.
+osc_sha1_examples() ->
+    [
+        {<<"a">>, <<"af75371eb751df0016370c3d28d2ad74670d5e52">>, <<"2014-06-25 11:43:48 -0400SFaNUO5tJTntDSilxtw0slOcoVgmFg">>},
+        {<<"b">>, <<"076e95e29e26ba631c862a8281aba6049b6ec920">>, <<"2014-06-25 11:43:48 -04004nADNlKYncv6iBBEsISgV7iPvMuQbk">>},
+        {<<"fizzbuz">>, <<"e49b70947b5e6358111b17be0f5c37d34d2afbe6">>, <<"2014-06-25 11:43:48 -0400m7acRVNa3P6Yg4qpnDisCFvA8bEqSm">>},
+        {<<"sesame">>, <<"537abd120fcc28e5be3b2faa2aeafe5f47d0171d">>, <<"2014-06-25 11:43:48 -0400FjzotYDqRB2o4IFbcHKMX30x8iIZsM">>},
+        {<<"apple">>, <<"7dd7b5cc04a7b3f59098356fa582c17834ba98a8">>, <<"2014-06-25 11:43:48 -04002ZMgJTBxbCVPCiXhlvVKpuTA2J6YLq">>}
+    ].
+ec_sha1_examples() ->
+    [
+        {<<"a">>, <<"8975d201890516f658ff92f4df9068027707a03f">>, <<"2014-06-25 11:43:48 -0400fpk83jDbAOc0OBcV4ogF653GVVOMRn">>},
+        {<<"b">>, <<"17ee8561bf7397150e71174517ab974cdd65b82e">>, <<"2014-06-25 11:43:48 -0400jQVVx4gq6Ehk2DbZ4vaY8nOh5FY5cx">>},
+        {<<"fizzbuz">>, <<"3da5133e640f88d230aa5e7eccb6d416496e1552">>, <<"2014-06-25 11:43:48 -04006gpZ4GsmEeFPFBhQ0KgnIEWzB8HwPF">>},
+        {<<"sesame">>, <<"29540420f534f6542b344e3ef861ac3cfc0bf497">>, <<"2014-06-25 11:43:48 -0400BnDpBdHxSehr7t8evqsuhATbhQpZbT">>},
+        {<<"apple">>, <<"602f9c8cbec7f723205957e5ab79aa384a97c76c">>, <<"2014-06-25 11:43:48 -0400WhloJNsMAmlIHDXrOIUmLVPc3y0T3M">>}
+    ].
+
+%% migration data generators
+osc_migrated_examples() ->
+    [ {Password, do_osc_migration(SHA1, Salt)} || {Password, SHA1, Salt} <- osc_sha1_examples()  ].
+
+
+ec_migrated_examples() ->
+    [ {Password, do_ec_migration(SHA1, Salt)} || {Password, SHA1, Salt} <- ec_sha1_examples()  ].
+
+% Perform midway migration to sha+bcrypt for OSC
+% this function only existed in chef_password for purpsoses
+% of testing, so it is moved here
+do_osc_migration(SHA, Salt) ->
+    {ok, BcryptSalt} = bcrypt:gen_salt(),
+    {ok, HashedPass} = bcrypt:hashpw(SHA, BcryptSalt),
+    CompoundSalt = iolist_to_binary([BcryptSalt, <<"\t">>, Salt]),
+    {list_to_binary(HashedPass), CompoundSalt, ?OSC_MIGRATION_HASH_TYPE}.
+
+
+% Perform midway migration to sha+bcrypt for EC
+% this currently exists in chef_mover/src/mover_user_hash_converter.erl
+% and is executed during the user password migration phase of an EC upgrade.
+% Very similar to OSC migration, but does not store compound salt - instead
+% stores the original salt, because bcrypt salt is part of the bcrypt hash itself.
+do_ec_migration(SHA, Salt) ->
+    {ok, BcryptSalt} = bcrypt:gen_salt(),
+    {ok, HashedPass} = bcrypt:hashpw(SHA, BcryptSalt),
+    {list_to_binary(HashedPass), Salt, ?MIGRATION_HASH_TYPE}.
+

--- a/test/test_utils.erl
+++ b/test/test_utils.erl
@@ -24,6 +24,8 @@
          mock/1,
          mock/2,
          unmock/1,
+         bcrypt_setup/0,
+         bcrypt_cleanup/1,
          validate_modules/1
         ]).
 
@@ -50,3 +52,22 @@ unmock(Modules) ->
 validate_modules(Modules) ->
     [?assert(meck:validate(M)) || M <- Modules].
 
+bcrypt_setup() ->
+    application:set_env(bcrypt, default_log_rounds, 4),
+    [ ensure_start(App) || App <- [crypto, bcrypt] ],
+    ok.
+
+bcrypt_cleanup(_) ->
+    error_logger:tty(false),
+    application:stop(bcrypt),
+    error_logger:tty(true).
+
+ensure_start(App) ->
+    case application:start(App) of
+        ok ->
+            ok;
+        {error, {already_started, App}} ->
+            ok;
+        Error ->
+            error(Error)
+    end.


### PR DESCRIPTION
- add renamed module and test files. (chef_wm_password -> chef_password, chef_wm_password_tests -> chef_password_tests) 
- move password extraction and conversion to be contained within
  chef_user:new_record and chef_user:update_from_ejson
- expand test converage to include password updates
  and serialized object merge behavior

ping @opscode/server-team 
