### PR TITLE
return public_key for clients in all cases

### DIFF
--- a/src/chef_client.erl
+++ b/src/chef_client.erl
@@ -127,7 +127,7 @@ update_from_ejson(#chef_client{} = Client, ClientData) ->
     Name = ej:get({<<"name">>}, ClientData),
     IsAdmin = ej:get({<<"admin">>}, ClientData) =:= true,
     IsValidator = ej:get({<<"validator">>}, ClientData) =:= true,
-    %% Take certificate first, then public_key
+    %% Take public_key first, then certificate
     {Key, Version} = cert_or_key(ClientData),
     case Key of
         undefined ->
@@ -440,11 +440,11 @@ cert_or_key(Payload) ->
     Cert = value_or_undefined({<<"certificate">>}, Payload),
     PublicKey = value_or_undefined({<<"public_key">>}, Payload),
     %% Take certificate first, then public_key
-    case Cert of
+    case PublicKey of
         undefined ->
-            {PublicKey, ?KEY_VERSION};
+            {Cert, ?CERT_VERSION};
         _ ->
-            {Cert, ?CERT_VERSION}
+            {PublicKey, ?KEY_VERSION}
     end.
 
 value_or_undefined(Key, Data) ->

--- a/src/chef_client.erl
+++ b/src/chef_client.erl
@@ -232,17 +232,14 @@ oc_assemble_client_ejson(#chef_client{name = Name, validator = Validator,
     Values = [{<<"name">>, value_or_default(Name, <<"">>)},
               {<<"clientname">>, value_or_default(Name, <<"">>)},
               {<<"validator">>, Validator =:= true},
-              {<<"orgname">>, OrgName}],
+              {<<"orgname">>, OrgName},
+              {<<"json_class">>, <<"Chef::ApiClient">>},
+              {<<"chef_type">>, <<"client">>}],
     case PublicKey of
         undefined ->
             {Values};
         _ ->
-            case chef_object_base:key_version(PublicKey) of
-                0 ->
-                    {[{<<"public_key">>, PublicKey} | Values]};
-                1 ->
-                    {[{<<"certificate">>, PublicKey} | Values]}
-            end
+            {[{<<"public_key">>, chef_object_base:extract_public_key(PublicKey)} | Values]}
     end.
 
 %% @doc creates the json body for clients

--- a/src/chef_object_base.erl
+++ b/src/chef_object_base.erl
@@ -28,8 +28,10 @@
 -include_lib("ej/include/ej.hrl").
 
 -export([
+         cert_or_key/1,
          delete_null_public_key/1,
          depsolver_constraints/1,
+         extract_public_key/1,
          key_version/1,
          make_org_prefix_id/1,
          make_org_prefix_id/2,
@@ -43,8 +45,7 @@
          strictly_valid/3,
          sql_date/1,
          throw_invalid_fun_match/1,
-         valid_public_key/1,
-         cert_or_key/1
+         valid_public_key/1
         ]).
 
 %% In order to fully test things
@@ -239,6 +240,14 @@ cert_or_key(Payload) ->
             {PublicKey, ?KEY_VERSION};
         _ ->
             {Cert, ?CERT_VERSION}
+    end.
+
+extract_public_key(Data) ->
+    case key_version(Data) of
+        ?KEY_VERSION ->
+            Data;
+        ?CERT_VERSION ->
+            chef_authn:extract_pem_encoded_public_key(Data)
     end.
 
 %% Hack to get null public_key accepted as undefined

--- a/src/chef_user.erl
+++ b/src/chef_user.erl
@@ -225,7 +225,7 @@ assemble_user_ejson(#chef_user{username = Name,
     % public_key can mean either public key or cert.
     % if it's a cert, we need to extract the public key -
     % we don't want to hand the cert back on user GET.
-    RealPubKey = real_pub_key(KeyOrCert),
+    RealPubKey = chef_object_base:extract_public_key(KeyOrCert),
     % Where external auth is enable, email may be null/undefined
     Email2 = case Email of
         undefined -> <<"">>;
@@ -241,14 +241,6 @@ assemble_user_ejson(#chef_user{username = Name,
 
     { User1 ++ User2 }.
 
-
-real_pub_key(Data) ->
-    case chef_object_base:key_version(Data) of
-        ?KEY_VERSION ->
-            Data;
-        ?CERT_VERSION ->
-            chef_authn:extract_pem_encoded_public_key(Data)
-    end.
 
 %% @doc Convert a binary JSON string representing a Chef User into an
 %% EJson-encoded Erlang data structure.


### PR DESCRIPTION
To be consistent with the open-source API and tools that are depending
on it, we should always return public keys with client objects instead
of certificates. The following is a situation that we've recently
encountered:
- consumer of API switches on the response having json_class field
- response inflates to a Chef::ApiClient if json_class is set
- if inflated, consumer expects the public_key field to be set
- if not inflated (no json_class), consumer expects certificate
  field to be set

This commit ensures that we always set both json_class and
public_key, the combination that the Ruby chef-client code expects.
